### PR TITLE
Fix SignalSlotService::hideLocation when content type is unsupported

### DIFF
--- a/src/lib/Service/SignalSlotService.php
+++ b/src/lib/Service/SignalSlotService.php
@@ -134,7 +134,7 @@ class SignalSlotService implements SignalSlotServiceInterface
 
         $content = $this->getContent($location->contentId);
         
-        if (!isset($content)) {
+        if (!$content instanceof Content) {
             return;
         }
         

--- a/src/lib/Service/SignalSlotService.php
+++ b/src/lib/Service/SignalSlotService.php
@@ -133,7 +133,11 @@ class SignalSlotService implements SignalSlotServiceInterface
         }
 
         $content = $this->getContent($location->contentId);
-
+        
+        if (!isset($content)) {
+            return;
+        }
+        
         if (!$isChild && $this->isLocationsAreVisible($content->contentInfo)) {
             return;
         }


### PR DESCRIPTION
getContent() returns NULL when content type is not configured as supported.
This results in a fatal error, when calling $content->contentInfo.