### PR TITLE
EZEE-3137: Changed default value for document_root option

### DIFF
--- a/src/bundle/DependencyInjection/Configuration.php
+++ b/src/bundle/DependencyInjection/Configuration.php
@@ -73,7 +73,7 @@ class Configuration extends SiteAccessConfiguration
                         ->end()
                     ->end()
                     ->scalarNode('document_root')
-                        ->defaultValue('%kernel.project_dir%/web/var/export/')
+                        ->defaultValue('%kernel.project_dir%/public/var/export/')
                     ->end()
                 ->end()
             ->end()


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZEE-3137

## Description 

`web` directory has been replaced by `public` in SF >= 4

