### PR TITLE
Fixed UserTracking Function

### DIFF
--- a/src/bundle/Templating/Twig/Functions/UserTracking.php
+++ b/src/bundle/Templating/Twig/Functions/UserTracking.php
@@ -70,7 +70,7 @@ final class UserTracking extends AbstractFunction implements RuntimeExtensionInt
         }
 
         return $this->twig->render(
-            'EzRecommendationClientBundle::track_user.html.twig',
+            '@EzRecommendationClient/track_user.html.twig',
             [
                 'contentId' => $contentId,
                 'contentTypeId' => $this->contentTypeHelper->getContentTypeId(
@@ -81,9 +81,8 @@ final class UserTracking extends AbstractFunction implements RuntimeExtensionInt
                 'customerId' => $customerId,
                 'consumeTimeout' => $this->getConsumeTimeout(),
                 'trackingScriptUrl' => $this->configResolver->getParameter(
-                    'event_tracking.script_url',
-                    Parameters::NAMESPACE,
-                    Parameters::API_SCOPE
+                    Parameters::API_SCOPE . '.event_tracking.script_url',
+                    Parameters::NAMESPACE
                 ),
             ]
         );
@@ -92,9 +91,8 @@ final class UserTracking extends AbstractFunction implements RuntimeExtensionInt
     private function getConsumeTimeout(): int
     {
         $consumeTimout = (int)$this->configResolver->getParameter(
-            'recommendation.consume_timeout',
-            Parameters::NAMESPACE,
-            Parameters::API_SCOPE
+            Parameters::API_SCOPE . '.recommendation.consume_timeout',
+            Parameters::NAMESPACE
         );
 
         return $consumeTimout * 1000;

--- a/src/bundle/Templating/Twig/RecommendationExtension.php
+++ b/src/bundle/Templating/Twig/RecommendationExtension.php
@@ -32,7 +32,6 @@ final class RecommendationExtension extends AbstractExtension
             new TwigFunction('ez_recommendation_enabled', [Recommendation::class, 'isRecommendationsEnabled']),
             new TwigFunction('ez_recommendation_track_user', [UserTracking::class, 'trackUser'], [
                 'is_safe' => ['html'],
-                'needs_environment' => true,
             ]),
         ];
     }


### PR DESCRIPTION
There is an error: 
> php.CRITICAL: Uncaught Error: Argument 1 passed to EzSystems\EzRecommendationClientBundle\Templating\Twig\Functions\UserTracking::trackUser() must be of the type int, object given, called in /app/var/cache/prod/twig/06/063f888a52788fd23cca69eef6642b3d7305014ddc45bf166f7129243a18c72e.php on line 81 {"exception":"[object] (TypeError(code: 0): Argument 1 passed to EzSystems\\EzRecommendationClientBundle\\Templating\\Twig\\Functions\\UserTracking::trackUser() must be of the type int, object given, called in /app/var/cache/prod/twig/06/063f888a52788fd23cca69eef6642b3d7305014ddc45bf166f7129243a18c72e.php on line 81 at /app/vendor/ezsystems/ezrecommendation-client/src/bundle/Templating/Twig/Functions/UserTracking.php:63)"} []

**paramName** passing to configResolver->getParameter() should be fixed.

Template path for tracker script was invalid as well