### PR TITLE
RSYS-3135: Dropped subscribed events for create and update content

### DIFF
--- a/src/lib/Event/Subscriber/ContentEventSubscriber.php
+++ b/src/lib/Event/Subscriber/ContentEventSubscriber.php
@@ -27,8 +27,6 @@ final class ContentEventSubscriber extends AbstractCoreEventSubscriber implement
     public static function getSubscribedEvents(): array
     {
         return [
-            CreateContentEvent::class => ['onCreateContent', parent::EVENT_PRIORITY],
-            UpdateContentEvent::class => ['onUpdateContent', parent::EVENT_PRIORITY],
             DeleteContentEvent::class => ['onDeleteContent', parent::EVENT_PRIORITY],
             HideContentEvent::class => ['onHideContent', parent::EVENT_PRIORITY],
             RevealContentEvent::class => ['onRevealContent', parent::EVENT_PRIORITY],
@@ -36,32 +34,6 @@ final class ContentEventSubscriber extends AbstractCoreEventSubscriber implement
             CopyContentEvent::class => ['onCopyContent', parent::EVENT_PRIORITY],
             PublishVersionEvent::class => ['onPublishVersion', parent::EVENT_PRIORITY],
         ];
-    }
-
-    /**
-     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
-     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
-     */
-    public function onCreateContent(CreateContentEvent $event): void
-    {
-        $this->notificationService->sendNotification(
-            __METHOD__,
-            EventNotification::ACTION_UPDATE,
-            $event->getContent()->contentInfo
-        );
-    }
-
-    /**
-     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
-     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
-     */
-    public function onUpdateContent(UpdateContentEvent $event): void
-    {
-        $this->notificationService->sendNotification(
-            __METHOD__,
-            EventNotification::ACTION_UPDATE,
-            $event->getContent()->contentInfo
-        );
     }
 
     /**

--- a/tests/lib/Event/Subscriber/ContentEventSubscriberTest.php
+++ b/tests/lib/Event/Subscriber/ContentEventSubscriberTest.php
@@ -44,8 +44,6 @@ class ContentEventSubscriberTest extends AbstractCoreEventSubscriberTest
     public function subscribedEventsDataProvider(): array
     {
         return [
-            [CreateContentEvent::class],
-            [UpdateContentEvent::class],
             [DeleteContentEvent::class],
             [HideContentEvent::class],
             [RevealContentEvent::class],
@@ -53,28 +51,6 @@ class ContentEventSubscriberTest extends AbstractCoreEventSubscriberTest
             [CopyContentEvent::class],
             [PublishVersionEvent::class],
         ];
-    }
-
-    public function testCallOnCreateContentMethod()
-    {
-        $event = $this->createMock(CreateContentEvent::class);
-        $event
-            ->expects($this->once())
-            ->method('getContent')
-            ->willReturn($this->content);
-
-        $this->contentEventSubscriber->onCreateContent($event);
-    }
-
-    public function testCallOnUpdateContentMethod()
-    {
-        $event = $this->createMock(UpdateContentEvent::class);
-        $event
-            ->expects($this->once())
-            ->method('getContent')
-            ->willReturn($this->content);
-
-        $this->contentEventSubscriber->onUpdateContent($event);
     }
 
     public function testCallOnDeleteContentMethod()


### PR DESCRIPTION
Dropped subscribing `CreateContentEvent` and `UpdateContentEvent` which are related to draft. Recommendation call with update action will be send after triggering `PublishVersionEvent` 

https://issues.ibexa.co/browse/RSYS-3135