### PR TITLE
EZEE-3407: Fixed hide Content Location

### DIFF
--- a/src/lib/Event/Subscriber/LocationEventSubscriber.php
+++ b/src/lib/Event/Subscriber/LocationEventSubscriber.php
@@ -159,10 +159,11 @@ final class LocationEventSubscriber extends AbstractRepositoryEventSubscriber im
             $this->locationService->loadLocation($location->id)->contentId
         );
 
-        if (!$content instanceof Content
-            && !$isChild
-            && $this->locationHelper->areLocationsVisible($content->contentInfo)
-        ) {
+        if (!$content instanceof Content) {
+            return;
+        }
+
+        if (!$isChild && $this->locationHelper->areLocationsVisible($content->contentInfo)) {
             return;
         }
 


### PR DESCRIPTION
https://issues.ibexa.co/browse/EZEE-3407

This PR provides fix for LocationEventSubscriber::hideLocation. If content will be not fetched, is not included in recommendation tracking or is not an instance of Content then  `$this->locationHelper->areLocationsVisible($content->contentInfo)` will be not executed.