### PR TITLE
EZEE-3331: Fixed LoginListener when user login via API

### DIFF
--- a/src/lib/Event/Listener/LoginListener.php
+++ b/src/lib/Event/Listener/LoginListener.php
@@ -63,6 +63,10 @@ final class LoginListener
 
     public function onSecurityInteractiveLogin(InteractiveLoginEvent $event): void
     {
+        if (!$event->getRequest()->get('is_rest_request')) {
+            return;
+        }
+
         if (!$this->authorizationChecker->isGranted('IS_AUTHENTICATED_FULLY') // user has just logged in
             || !$this->authorizationChecker->isGranted('IS_AUTHENTICATED_REMEMBERED') // user has logged in using remember_me cookie
         ) {


### PR DESCRIPTION
https://issues.ibexa.co/browse/EZEE-3331

This PR provides fix to `LoginListener::onSecurityInteractiveLogin` method. If request is not type of REST request then recommendation client should send login event notification and start tracking logged user. 