### PR TITLE
RSYS-3134: Fixed thrown exception if reco API is not available

### DIFF
--- a/src/lib/Service/NotificationService.php
+++ b/src/lib/Service/NotificationService.php
@@ -61,5 +61,7 @@ abstract class NotificationService
         } catch (RequestException $e) {
             $this->logger->error(sprintf('RecommendationNotifier: notification error for %s: %s', $action, $e->getMessage()));
         }
+
+        return null;
     }
 }


### PR DESCRIPTION
https://issues.ibexa.co/browse/RSYS-3134

This PR provides fix for exception

> Return value of EzSystems\EzRecommendationClient\Service\NotificationService::send() must implement interface Psr\Http\Message\ResponseInterface or be null, none returned


Version 1.X is not affected