### PR TITLE
IBX-607: Extended ItemListInterface on method fromTraversable

### DIFF
--- a/src/contracts/Value/ItemListInterface.php
+++ b/src/contracts/Value/ItemListInterface.php
@@ -9,12 +9,12 @@ declare(strict_types=1);
 namespace Ibexa\Contracts\Personalization\Value;
 
 use Countable;
-use IteratorAggregate;
+use Traversable;
 
 /**
- * @extends IteratorAggregate<ItemInterface>
+ * @extends Traversable<\Ibexa\Contracts\Personalization\Value\ItemInterface>
  */
-interface ItemListInterface extends IteratorAggregate, Countable
+interface ItemListInterface extends Traversable, Countable
 {
     /**
      * @throws \EzSystems\EzRecommendationClient\Exception\ItemNotFoundException
@@ -34,4 +34,9 @@ interface ItemListInterface extends IteratorAggregate, Countable
      * Returns a new ItemInterface collection sliced of $length elements starting at position $offset.
      */
     public function slice(int $offset, ?int $length = null): self;
+
+    /**
+     * @param Traversable<\Ibexa\Contracts\Personalization\Value\ItemInterface> $traversable
+     */
+    public static function fromTraversable(Traversable $traversable): self;
 }


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-607](https://issues.ibexa.co/browse/IBX-607)
| **Type**                                   | feature
| **Target Ibexa DXP version** | `v4.0.0`

Added static method `fromTraversable` to create ItemList from traversable class.
See: https://github.com/ezsystems/ezrecommendation-client/pull/53/files#diff-55d3687e4f041f123182193efc13e812cb2fb80f291f8e94d20e2b0416defb50R85-R88

#### Checklist:
- [x] Provided PR description.
- [ ] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/php-dev-team`).
