### PR TITLE
Fixed "index" key for tagged_iterator

### DIFF
--- a/src/bundle/Resources/config/services/strategies.yaml
+++ b/src/bundle/Resources/config/services/strategies.yaml
@@ -16,7 +16,7 @@ services:
             $strategies: !tagged_iterator 
                 tag: ibexa.personalization.group_item.strategy
                 default_index_method: getIndex
-                index: key
+                index_by: key
 
     EzSystems\EzRecommendationClient\Strategy\Storage\GroupItemStrategyDispatcherInterface:
         '@EzSystems\EzRecommendationClient\Strategy\Storage\GroupItemStrategyDispatcher'


### PR DESCRIPTION
This PR fixes error reported by Travis: 

Executing script cache:clear [KO]
 [KO]
Script cache:clear returned with error code 1
!!  
!!  In FileLoader.php line 174:
!!                                                                                 
!!    "!tagged_iterator" tag contains unsupported key "index"; supported ones are  
!!     "tag", "index_by", "default_index_method", and "default_priority_method" i  
!!    n /var/www/vendor/ezsystems/ezrecommendation-client/src/bundle/DependencyIn  
!!    jection/../Resources/config/services/strategies.yaml (which is being import  
!!    ed from "/var/www/vendor/ezsystems/ezrecommendation-client/src/bundle/Depen  
!!    dencyInjection/../Resources/config/services.yaml").                          
!!                                                                                 
!!  
!!  In YamlFileLoader.php line 854:
!!                                                                                 
!!    "!tagged_iterator" tag contains unsupported key "index"; supported ones are  
!!     "tag", "index_by", "default_index_method", and "default_priority_method". 