### PR TITLE
Refactored CredentialsResolver

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -361,21 +361,6 @@ parameters:
 			path: src/lib/Client/EzRecommendationClientInterface.php
 
 		-
-			message: "#^Method EzSystems\\\\EzRecommendationClient\\\\Config\\\\CredentialsResolver\\:\\:getRequiredCredentials\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/lib/Config/CredentialsResolver.php
-
-		-
-			message: "#^Method EzSystems\\\\EzRecommendationClient\\\\Config\\\\ExportCredentialsResolver\\:\\:getRequiredCredentials\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/lib/Config/ExportCredentialsResolver.php
-
-		-
-			message: "#^Method EzSystems\\\\EzRecommendationClient\\\\Config\\\\EzRecommendationClientCredentialsResolver\\:\\:getRequiredCredentials\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/lib/Config/EzRecommendationClientCredentialsResolver.php
-
-		-
 			message: "#^Call to an undefined method GuzzleHttp\\\\ClientInterface\\:\\:get\\(\\)\\.$#"
 			count: 1
 			path: src/lib/Event/Listener/LoginListener.php
@@ -1519,21 +1504,6 @@ parameters:
 			message: "#^Property EzSystems\\\\EzRecommendationClient\\\\Tests\\\\Config\\\\CredentialsResolverTest\\:\\:\\$loggerMock \\(PHPUnit\\\\Framework\\\\MockObject\\\\MockObject&Psr\\\\Log\\\\NullLogger\\) does not accept PHPUnit\\\\Framework\\\\MockObject\\\\MockObject&Psr\\\\Log\\\\LoggerInterface\\.$#"
 			count: 1
 			path: tests/lib/Config/CredentialsResolverTest.php
-
-		-
-			message: "#^Method EzSystems\\\\EzRecommendationClient\\\\Tests\\\\Config\\\\ExportCredentialsResolverTest\\:\\:testCreateExportCredentialsResolverInstance\\(\\) has no return typehint specified\\.$#"
-			count: 1
-			path: tests/lib/Config/ExportCredentialsResolverTest.php
-
-		-
-			message: "#^Method EzSystems\\\\EzRecommendationClient\\\\Tests\\\\Config\\\\ExportCredentialsResolverTest\\:\\:testGetCredentialsForAuthenticationMethodUser\\(\\) has no return typehint specified\\.$#"
-			count: 1
-			path: tests/lib/Config/ExportCredentialsResolverTest.php
-
-		-
-			message: "#^Method EzSystems\\\\EzRecommendationClient\\\\Tests\\\\Config\\\\ExportCredentialsResolverTest\\:\\:testReturnNullWhenMethodIsUserAndHasCredentialsIsFalse\\(\\) has no return typehint specified\\.$#"
-			count: 1
-			path: tests/lib/Config/ExportCredentialsResolverTest.php
 
 		-
 			message: "#^Method EzSystems\\\\EzRecommendationClient\\\\Tests\\\\Config\\\\EzRecommendationClientCredentialsResolverTest\\:\\:testCreateEzRecommendationClientCredentialsResolverInstance\\(\\) has no return typehint specified\\.$#"

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -301,16 +301,6 @@ parameters:
 			path: src/lib/Authentication/ExportAuthenticator.php
 
 		-
-			message: "#^Cannot call method getCustomerId\\(\\) on EzSystems\\\\EzRecommendationClient\\\\Value\\\\Config\\\\Credentials\\|null\\.$#"
-			count: 1
-			path: src/lib/Client/EzRecommendationClient.php
-
-		-
-			message: "#^Cannot call method getLicenseKey\\(\\) on EzSystems\\\\EzRecommendationClient\\\\Value\\\\Config\\\\Credentials\\|null\\.$#"
-			count: 1
-			path: src/lib/Client/EzRecommendationClient.php
-
-		-
 			message: "#^Method EzSystems\\\\EzRecommendationClient\\\\Client\\\\EzRecommendationClient\\:\\:__call\\(\\) has parameter \\$arguments with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/lib/Client/EzRecommendationClient.php
@@ -1334,16 +1324,6 @@ parameters:
 			message: "#^Method EzSystems\\\\EzRecommendationClient\\\\Service\\\\RecommendationServiceInterface\\:\\:getRecommendationItems\\(\\) has parameter \\$recommendationItems with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/lib/Service/RecommendationServiceInterface.php
-
-		-
-			message: "#^Method EzSystems\\\\EzRecommendationClient\\\\Value\\\\Config\\\\ExportCredentials\\:\\:__construct\\(\\) has parameter \\$credentials with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/lib/Value/Config/ExportCredentials.php
-
-		-
-			message: "#^Method EzSystems\\\\EzRecommendationClient\\\\Value\\\\Config\\\\EzRecommendationClientCredentials\\:\\:__construct\\(\\) has parameter \\$credentials with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/lib/Value/Config/EzRecommendationClientCredentials.php
 
 		-
 			message: "#^Method EzSystems\\\\EzRecommendationClient\\\\Value\\\\ContentData\\:\\:__construct\\(\\) has parameter \\$contents with no value type specified in iterable type array\\.$#"

--- a/src/lib/Client/EzRecommendationClient.php
+++ b/src/lib/Client/EzRecommendationClient.php
@@ -29,10 +29,10 @@ final class EzRecommendationClient implements EzRecommendationClientInterface
     private const ERROR_MESSAGE = 'ClientError: ';
     private const MESSAGE_SEPARATOR = ' | ';
 
-    /** @var int */
+    /** @var ?int */
     private $customerId;
 
-    /** @var string */
+    /** @var ?string */
     private $licenseKey;
 
     /** @var \GuzzleHttp\ClientInterface */
@@ -69,7 +69,7 @@ final class EzRecommendationClient implements EzRecommendationClientInterface
     /**
      * {@inheritdoc}
      */
-    public function setCustomerId(int $customerId): EzRecommendationClientInterface
+    public function setCustomerId(?int $customerId = null): EzRecommendationClientInterface
     {
         $this->customerId = $customerId;
 
@@ -87,7 +87,7 @@ final class EzRecommendationClient implements EzRecommendationClientInterface
     /**
      * {@inheritdoc}
      */
-    public function setLicenseKey(string $licenseKey): EzRecommendationClientInterface
+    public function setLicenseKey(?string $licenseKey = null): EzRecommendationClientInterface
     {
         $this->licenseKey = $licenseKey;
 
@@ -217,9 +217,11 @@ final class EzRecommendationClient implements EzRecommendationClientInterface
     {
         $credentials = $this->credentialsResolver->getCredentials();
 
-        $this
-            ->setCustomerId($credentials->getCustomerId())
-            ->setLicenseKey($credentials->getLicenseKey());
+        if (null !== $credentials) {
+            $this
+                ->setCustomerId($credentials->getCustomerId())
+                ->setLicenseKey($credentials->getLicenseKey());
+        }
     }
 
     private function getRequestLogMessage(array $transaction): string

--- a/src/lib/Client/EzRecommendationClientInterface.php
+++ b/src/lib/Client/EzRecommendationClientInterface.php
@@ -24,14 +24,14 @@ interface EzRecommendationClientInterface
     /**
      * @return \EzSystems\EzRecommendationClient\Client\EzRecommendationClientInterface
      */
-    public function setCustomerId(int $customerId): self;
+    public function setCustomerId(?int $customerId = null): self;
 
     public function getCustomerId(): ?int;
 
     /**
      * @return \EzSystems\EzRecommendationClient\Client\EzRecommendationClientInterface
      */
-    public function setLicenseKey(string $licenseKey): self;
+    public function setLicenseKey(?string $licenseKey = null): self;
 
     public function getLicenseKey(): ?string;
 

--- a/src/lib/Config/CredentialsResolver.php
+++ b/src/lib/Config/CredentialsResolver.php
@@ -12,25 +12,22 @@ use eZ\Publish\Core\MVC\ConfigResolverInterface;
 
 abstract class CredentialsResolver implements CredentialsResolverInterface
 {
-    /** @var \eZ\Publish\Core\MVC\ConfigResolverInterface */
-    protected $configResolver;
+    protected ConfigResolverInterface $configResolver;
 
     public function __construct(ConfigResolverInterface $configResolver)
     {
         $this->configResolver = $configResolver;
     }
 
+    /**
+     * @return array<string>
+     */
     abstract protected function getRequiredCredentials(?string $siteAccess = null): array;
 
-    /**
-     * {@inheritdoc}
-     */
     public function hasCredentials(?string $siteAccess = null): bool
     {
-        $credentials = $this->getRequiredCredentials($siteAccess);
-
-        foreach ($credentials as $credentialKey => $credentialValue) {
-            if (empty($credentialValue)) {
+        foreach ($this->getRequiredCredentials($siteAccess) as $credential) {
+            if (empty($credential)) {
                 return false;
             }
         }

--- a/src/lib/Config/CredentialsResolver.php
+++ b/src/lib/Config/CredentialsResolver.php
@@ -20,10 +20,13 @@ abstract class CredentialsResolver implements CredentialsResolverInterface
     }
 
     /**
-     * @return array<string>
+     * @return array<string, int|string|null>
      */
     abstract protected function getRequiredCredentials(?string $siteAccess = null): array;
 
+    /**
+     * Checks if array returned by getRequiredCredentials method contains valid values retrieved by ConfigResolver.
+     */
     public function hasCredentials(?string $siteAccess = null): bool
     {
         foreach ($this->getRequiredCredentials($siteAccess) as $credential) {

--- a/src/lib/Config/CredentialsResolverInterface.php
+++ b/src/lib/Config/CredentialsResolverInterface.php
@@ -17,5 +17,5 @@ interface CredentialsResolverInterface
      */
     public function getCredentials(?string $siteAccess = null): ?Credentials;
 
-    public function hasCredentials(): bool;
+    public function hasCredentials(?string $siteAccess = null): bool;
 }

--- a/src/lib/Config/ExportCredentialsResolver.php
+++ b/src/lib/Config/ExportCredentialsResolver.php
@@ -8,22 +8,24 @@ declare(strict_types=1);
 
 namespace EzSystems\EzRecommendationClient\Config;
 
-use EzSystems\EzRecommendationClient\Value\Config\Credentials;
 use EzSystems\EzRecommendationClient\Value\Config\ExportCredentials;
 use EzSystems\EzRecommendationClient\Value\ExportMethod;
 use EzSystems\EzRecommendationClient\Value\Parameters;
 
 final class ExportCredentialsResolver extends CredentialsResolver
 {
-    public function getCredentials(?string $siteAccess = null): ?Credentials
+    public function getCredentials(?string $siteAccess = null): ?ExportCredentials
     {
         $requiredCredentials = $this->getRequiredCredentials($siteAccess);
 
-        if ($requiredCredentials['method'] === ExportMethod::USER && !$this->hasCredentials($siteAccess)) {
+        if (
+            $requiredCredentials[ExportCredentials::METHOD_KEY] === ExportMethod::USER
+            && !$this->hasCredentials($siteAccess)
+        ) {
             return null;
         }
 
-        return new ExportCredentials($requiredCredentials);
+        return ExportCredentials::fromArray($requiredCredentials);
     }
 
     /**
@@ -36,17 +38,17 @@ final class ExportCredentialsResolver extends CredentialsResolver
     protected function getRequiredCredentials(?string $siteAccess = null): array
     {
         return [
-            'method' => $this->configResolver->getParameter(
+            ExportCredentials::METHOD_KEY => $this->configResolver->getParameter(
                 'export.authentication.method',
                 Parameters::NAMESPACE,
                 $siteAccess
             ),
-            'login' => $this->configResolver->getParameter(
+            ExportCredentials::LOGIN_KEY => $this->configResolver->getParameter(
                 'export.authentication.login',
                 Parameters::NAMESPACE,
                 $siteAccess
             ),
-            'password' => $this->configResolver->getParameter(
+            ExportCredentials::PASSWORD_KEY => $this->configResolver->getParameter(
                 'export.authentication.password',
                 Parameters::NAMESPACE,
                 $siteAccess

--- a/src/lib/Config/ExportCredentialsResolver.php
+++ b/src/lib/Config/ExportCredentialsResolver.php
@@ -15,34 +15,32 @@ use EzSystems\EzRecommendationClient\Value\Parameters;
 
 final class ExportCredentialsResolver extends CredentialsResolver
 {
-    /** @var string */
-    private $method;
-
-    /**
-     * {@inheritdoc}
-     */
     public function getCredentials(?string $siteAccess = null): ?Credentials
     {
-        $this->method = $this->configResolver->getParameter(
-            'export.authentication.method',
-            Parameters::NAMESPACE,
-            $siteAccess
-        );
+        $requiredCredentials = $this->getRequiredCredentials($siteAccess);
 
-        if ($this->method === ExportMethod::USER && !$this->hasCredentials($siteAccess)) {
+        if ($requiredCredentials['method'] === ExportMethod::USER && !$this->hasCredentials($siteAccess)) {
             return null;
         }
 
-        return new ExportCredentials($this->getRequiredCredentials($siteAccess));
+        return new ExportCredentials($requiredCredentials);
     }
 
     /**
-     * {@inheritdoc}
+     * @phpstan-return array{
+     *  'method': ?string,
+     *  'login': ?string,
+     *  'password': ?string,
+     * }
      */
     protected function getRequiredCredentials(?string $siteAccess = null): array
     {
         return [
-            'method' => $this->method,
+            'method' => $this->configResolver->getParameter(
+                'export.authentication.method',
+                Parameters::NAMESPACE,
+                $siteAccess
+            ),
             'login' => $this->configResolver->getParameter(
                 'export.authentication.login',
                 Parameters::NAMESPACE,

--- a/src/lib/Config/EzRecommendationClientCredentialsResolver.php
+++ b/src/lib/Config/EzRecommendationClientCredentialsResolver.php
@@ -8,36 +8,35 @@ declare(strict_types=1);
 
 namespace EzSystems\EzRecommendationClient\Config;
 
-use EzSystems\EzRecommendationClient\Value\Config\Credentials;
 use EzSystems\EzRecommendationClient\Value\Config\EzRecommendationClientCredentials;
 use EzSystems\EzRecommendationClient\Value\Parameters;
 
 final class EzRecommendationClientCredentialsResolver extends CredentialsResolver
 {
-    /**
-     * {@inheritdoc}
-     */
-    public function getCredentials(?string $siteAccess = null): ?Credentials
+    public function getCredentials(?string $siteAccess = null): ?EzRecommendationClientCredentials
     {
         if (!$this->hasCredentials($siteAccess)) {
             return null;
         }
 
-        return new EzRecommendationClientCredentials($this->getRequiredCredentials($siteAccess));
+        return EzRecommendationClientCredentials::fromArray($this->getRequiredCredentials($siteAccess));
     }
 
     /**
-     * {@inheritdoc}
+     * @phpstan-return array{
+     *  'customerId': ?int,
+     *  'licenseKey': ?string,
+     * }
      */
     protected function getRequiredCredentials(?string $siteAccess = null): array
     {
         return [
-            'customerId' => $this->configResolver->getParameter(
+            EzRecommendationClientCredentials::CUSTOMER_ID_KEY => $this->configResolver->getParameter(
                 'authentication.customer_id',
                 Parameters::NAMESPACE,
                 $siteAccess
             ),
-            'licenseKey' => $this->configResolver->getParameter(
+            EzRecommendationClientCredentials::LICENSE_KEY_KEY => $this->configResolver->getParameter(
                 'authentication.license_key',
                 Parameters::NAMESPACE,
                 $siteAccess

--- a/src/lib/Value/Config/ExportCredentials.php
+++ b/src/lib/Value/Config/ExportCredentials.php
@@ -10,34 +10,54 @@ namespace EzSystems\EzRecommendationClient\Value\Config;
 
 final class ExportCredentials extends Credentials
 {
-    /** @var string */
-    private $method;
+    public const METHOD_KEY = 'method';
+    public const LOGIN_KEY = 'login';
+    public const PASSWORD_KEY = 'password';
 
-    /** @var string */
-    private $login;
+    private ?string $method;
 
-    /** @var string */
-    private $password;
+    private ?string $login;
 
-    public function __construct(array $credentials)
-    {
-        $this->method = $credentials['method'] ?? '';
-        $this->login = $credentials['login'] ?? '';
-        $this->password = $credentials['password'] ?? '';
+    private ?string $password;
+
+    public function __construct(
+        ?string $method = null,
+        ?string $login = null,
+        ?string $password = null
+    ) {
+        $this->method = $method;
+        $this->login = $login;
+        $this->password = $password;
     }
 
-    public function getMethod(): string
+    public function getMethod(): ?string
     {
         return $this->method;
     }
 
-    public function getLogin(): string
+    public function getLogin(): ?string
     {
         return $this->login;
     }
 
-    public function getPassword(): string
+    public function getPassword(): ?string
     {
         return $this->password;
+    }
+
+    /**
+     * @phpstan-param array{
+     *  'method': ?string,
+     *  'login': ?string,
+     *  'password': ?string,
+     * } $credentials
+     */
+    public static function fromArray(array $credentials): self
+    {
+        return new self(
+            $credentials[self::METHOD_KEY] ?? null,
+            $credentials[self::LOGIN_KEY] ?? null,
+            $credentials[self::PASSWORD_KEY] ?? null,
+        );
     }
 }

--- a/src/lib/Value/Config/EzRecommendationClientCredentials.php
+++ b/src/lib/Value/Config/EzRecommendationClientCredentials.php
@@ -10,25 +10,42 @@ namespace EzSystems\EzRecommendationClient\Value\Config;
 
 final class EzRecommendationClientCredentials extends Credentials
 {
-    /** @var int */
-    private $customerId;
+    public const CUSTOMER_ID_KEY = 'customerId';
+    public const LICENSE_KEY_KEY = 'licenseKey';
 
-    /** @var string */
-    private $licenseKey;
+    private ?int $customerId;
 
-    public function __construct(array $credentials)
-    {
-        $this->customerId = $credentials['customerId'] ?? null;
-        $this->licenseKey = $credentials['licenseKey'] ?? null;
+    private ?string $licenseKey;
+
+    public function __construct(
+        ?int $customerId = null,
+        ?string $licenseKey = null
+    ) {
+        $this->customerId = $customerId;
+        $this->licenseKey = $licenseKey;
     }
 
-    public function getCustomerId(): int
+    public function getCustomerId(): ?int
     {
         return $this->customerId;
     }
 
-    public function getLicenseKey(): string
+    public function getLicenseKey(): ?string
     {
         return $this->licenseKey;
+    }
+
+    /**
+     * @phpstan-param array{
+     *  'customerId': ?int,
+     *  'licenseKey': ?string,
+     * } $credentials
+     */
+    public static function fromArray(array $credentials): self
+    {
+        return new self(
+            $credentials[self::CUSTOMER_ID_KEY] ?? null,
+            $credentials[self::LICENSE_KEY_KEY] ?? null,
+        );
     }
 }

--- a/tests/lib/Authentication/ExportAuthenticatorTest.php
+++ b/tests/lib/Authentication/ExportAuthenticatorTest.php
@@ -257,10 +257,10 @@ class ExportAuthenticatorTest extends TestCase
 
     private function getExportCredentials(string $method = 'basic'): ExportCredentials
     {
-        return new ExportCredentials([
-            'method' => $method,
-            'login' => '1111',
-            'password' => 'password',
+        return ExportCredentials::fromArray([
+            ExportCredentials::METHOD_KEY => $method,
+            ExportCredentials::LOGIN_KEY => '1111',
+            ExportCredentials::PASSWORD_KEY => 'password',
         ]);
     }
 }

--- a/tests/lib/Config/ExportCredentialsResolverTest.php
+++ b/tests/lib/Config/ExportCredentialsResolverTest.php
@@ -25,17 +25,14 @@ class ExportCredentialsResolverTest extends TestCase
         parent::setUp();
     }
 
-    public function testCreateExportCredentialsResolverInstance()
+    public function testCreateExportCredentialsResolverInstance(): void
     {
         $this->assertInstanceOf(ExportCredentialsResolver::class, new ExportCredentialsResolver(
             $this->configResolver
         ));
     }
 
-    /**
-     * Test for getCredentials() method.
-     */
-    public function testGetCredentialsForAuthenticationMethodUser()
+    public function testGetCredentialsForAuthenticationMethodUser(): void
     {
         $credentialsResolver = new ExportCredentialsResolver(
             $this->configResolver
@@ -44,10 +41,7 @@ class ExportCredentialsResolverTest extends TestCase
         $this->assertInstanceOf(ExportCredentials::class, $credentialsResolver->getCredentials());
     }
 
-    /**
-     * Test for getCredentials() method.
-     */
-    public function testReturnNullWhenMethodIsUserAndHasCredentialsIsFalse()
+    public function testReturnNullWhenMethodIsUserAndHasCredentialsIsFalse(): void
     {
         $this->configResolver
             ->expects($this->at(0))

--- a/tests/lib/File/FileManagerTest.php
+++ b/tests/lib/File/FileManagerTest.php
@@ -293,10 +293,10 @@ class FileManagerTest extends TestCase
 
     private function getExportCredentials(string $method = 'basic'): ExportCredentials
     {
-        return new ExportCredentials([
-            'method' => $method,
-            'login' => '0001',
-            'password' => 'pass',
+        return ExportCredentials::fromArray([
+            ExportCredentials::METHOD_KEY => $method,
+            ExportCredentials::LOGIN_KEY => '0001',
+            ExportCredentials::PASSWORD_KEY => 'pass',
         ]);
     }
 }

--- a/tests/lib/Service/EventNotificationServiceTest.php
+++ b/tests/lib/Service/EventNotificationServiceTest.php
@@ -72,17 +72,26 @@ class EventNotificationServiceTest extends NotificationServiceTest
         $this->credentialsResolverMock
             ->expects($this->once())
             ->method('getCredentials')
-            ->willReturn(new EzRecommendationClientCredentials([
-                'customerId' => 12345,
-                'licenseKey' => '12345-12345-12345-12345',
-            ]));
+            ->willReturn(
+                EzRecommendationClientCredentials::fromArray(
+                    [
+                        'customerId' => 12345,
+                        'licenseKey' => '12345-12345-12345-12345',
+                    ]
+                )
+            );
 
         $this->exportCredentialsMock
             ->method('getCredentials')
-            ->willReturn(new ExportCredentials([
-                'login' => 12345,
-                'password' => '12345-12345-12345-12345',
-            ]));
+            ->willReturn(
+                ExportCredentials::fromArray(
+                    [
+                        ExportCredentials::METHOD_KEY => 'basic',
+                        ExportCredentials::LOGIN_KEY => '12345',
+                        ExportCredentials::PASSWORD_KEY => '12345-12345-12345-12345',
+                    ]
+                )
+            );
 
         $this->clientMock
             ->method('__call')


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **Type**                                   | improvement
| **Target Ibexa DXP version** | `v4.0.0`
| **BC breaks**                          | no
| **Doc needed**                       | no

This PR provides fixes for CredentialsResolver:

- refactored `ExportCredentialsResolver` and `CredentialsResolver`
- Changed `hasCredentials` method signature in CredentialsResolverInterface
- Fixed phpstan errors

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/php-dev-team`).
