### PR TITLE
Fixed passing authentication parameters to request

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -336,11 +336,6 @@ parameters:
 			path: src/lib/Client/EzRecommendationClient.php
 
 		-
-			message: "#^Method EzSystems\\\\EzRecommendationClient\\\\Client\\\\EzRecommendationClient\\:\\:sendRequest\\(\\) has parameter \\$option with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/lib/Client/EzRecommendationClient.php
-
-		-
 			message: "#^Parameter \\#4 \\$previous of class EzSystems\\\\EzRecommendationClient\\\\Exception\\\\BadResponseException constructor expects Exception\\|null, Throwable\\|null given\\.$#"
 			count: 1
 			path: src/lib/Client/EzRecommendationClient.php
@@ -352,11 +347,6 @@ parameters:
 
 		-
 			message: "#^Method EzSystems\\\\EzRecommendationClient\\\\Client\\\\EzRecommendationClientInterface\\:\\:__call\\(\\) has parameter \\$arguments with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/lib/Client/EzRecommendationClientInterface.php
-
-		-
-			message: "#^Method EzSystems\\\\EzRecommendationClient\\\\Client\\\\EzRecommendationClientInterface\\:\\:sendRequest\\(\\) has parameter \\$option with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/lib/Client/EzRecommendationClientInterface.php
 

--- a/src/lib/Client/EzRecommendationClient.php
+++ b/src/lib/Client/EzRecommendationClient.php
@@ -125,7 +125,7 @@ final class EzRecommendationClient implements EzRecommendationClientInterface
      *
      * @throws \GuzzleHttp\Exception\GuzzleException
      */
-    public function sendRequest(string $method, UriInterface $uri, array $option = []): ResponseInterface
+    public function sendRequest(string $method, UriInterface $uri, array $options = []): ResponseInterface
     {
         try {
             if (!$this->hasCredentials()) {
@@ -139,8 +139,12 @@ final class EzRecommendationClient implements EzRecommendationClientInterface
             $stack = HandlerStack::create();
             $stack->push($history);
 
-            $response = $this->getHttpClient()->request($method, $uri, array_merge($option, [
+            $response = $this->getHttpClient()->request($method, $uri, array_merge($options, [
                 'handler' => $stack,
+                'auth' => [
+                    $this->getCustomerId(),
+                    $this->getLicenseKey(),
+                ],
             ]));
 
             foreach ($container as $transaction) {

--- a/src/lib/Client/EzRecommendationClientInterface.php
+++ b/src/lib/Client/EzRecommendationClientInterface.php
@@ -42,7 +42,10 @@ interface EzRecommendationClientInterface
 
     public function getUserIdentifier(): ?string;
 
-    public function sendRequest(string $method, UriInterface $uri, array $option = []): ResponseInterface;
+    /**
+     * @param array<string, array|string|bool> $options
+     */
+    public function sendRequest(string $method, UriInterface $uri, array $options = []): ResponseInterface;
 
     public function getHttpClient(): ClientInterface;
 

--- a/src/lib/Client/EzRecommendationClientInterface.php
+++ b/src/lib/Client/EzRecommendationClientInterface.php
@@ -43,7 +43,7 @@ interface EzRecommendationClientInterface
     public function getUserIdentifier(): ?string;
 
     /**
-     * @param array<string, array|string|bool> $options
+     * @param array<string, array|scalar> $options
      */
     public function sendRequest(string $method, UriInterface $uri, array $options = []): ResponseInterface;
 


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **Type**                                   | improvement
| **Target Ibexa DXP version** | `v3.3.7` 
| **BC breaks**                          | no
| **Doc needed**                       | no

This PR provides fixed method for passing authentication parameters for requests. This change allow EzRecommendationClient to use credentials taken from methods `getCustomerId` and `getLicenseKey` and set those to option `auth`. Building own options with authentication parameters is not needed now.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/php-dev-team`).
