### PR TITLE
IBX-915: Added getId method to ItemTypeInterface

### DIFF
--- a/src/contracts/Value/ItemTypeInterface.php
+++ b/src/contracts/Value/ItemTypeInterface.php
@@ -12,5 +12,7 @@ interface ItemTypeInterface
 {
     public function getName(): string;
 
+    public function getId(): int;
+
     public function getIdentifier(): string;
 }

--- a/src/lib/Value/Storage/ItemType.php
+++ b/src/lib/Value/Storage/ItemType.php
@@ -15,17 +15,28 @@ final class ItemType implements ItemTypeInterface
 {
     private string $identifier;
 
+    private int $id;
+
     private string $name;
 
-    public function __construct(string $identifier, string $name)
-    {
+    public function __construct(
+        string $identifier,
+        int $id,
+        string $name
+    ) {
         $this->identifier = $identifier;
+        $this->id = $id;
         $this->name = $name;
     }
 
     public function getIdentifier(): string
     {
         return $this->identifier;
+    }
+
+    public function getId(): int
+    {
+        return $this->id;
     }
 
     public function getName(): string
@@ -37,6 +48,7 @@ final class ItemType implements ItemTypeInterface
     {
         return new self(
             $contentType->identifier,
+            $contentType->id,
             $contentType->getName() ?? $contentType->identifier
         );
     }

--- a/tests/lib/Creator/DataSourceTestItemCreator.php
+++ b/tests/lib/Creator/DataSourceTestItemCreator.php
@@ -27,17 +27,33 @@ final class DataSourceTestItemCreator
 {
     public const ITEM_BODY = 'body';
     public const ITEM_IMAGE = 'public/var/1/2/4/5/%s/%s';
-    public const ARTICLE_IDENTIFIER = 'article';
-    public const BLOG_IDENTIFIER = 'blog';
-    public const PRODUCT_IDENTIFIER = 'product';
+
     public const ARTICLE_NAME = 'Article';
+    public const ARTICLE_TYPE_ID = 1;
+    public const ARTICLE_TYPE_IDENTIFIER = 'article';
+    public const ARTICLE_TYPE_NAME = self::ARTICLE_NAME;
+
     public const BLOG_NAME = 'Blog';
+    public const BLOG_TYPE_ID = 2;
+    public const BLOG_TYPE_IDENTIFIER = 'blog';
+    public const BLOG_TYPE_NAME = self::BLOG_NAME;
+
     public const PRODUCT_NAME = 'Product';
+    public const PRODUCT_TYPE_ID = 3;
+    public const PRODUCT_TYPE_IDENTIFIER = 'product';
+    public const PRODUCT_TYPE_NAME = self::PRODUCT_NAME;
+
+    public const LANGUAGE_EN = 'en';
+    public const LANGUAGE_DE = 'de';
+    public const LANGUAGE_FR = 'fr';
+    public const LANGUAGE_NO = 'no';
+    public const ALL_LANGUAGES = [self::LANGUAGE_EN, self::LANGUAGE_DE, self::LANGUAGE_FR, self::LANGUAGE_NO];
 
     private int $lastGeneratedId = 1;
 
     /**
      * @phpstan-param ?iterable<string, array{
+     *  'item_type_id': int,
      *  'item_type_identifier': string,
      *  'item_type_name': string,
      *  'languages': array<string>,
@@ -56,13 +72,14 @@ final class DataSourceTestItemCreator
     public function createTestItem(
         int $counter,
         string $itemId,
+        int $itemTypeId,
         string $itemTypeIdentifier,
         string $itemTypeName,
         string $language
     ): ItemInterface {
         return new Item(
             $itemId,
-            $this->createTestItemType($itemTypeIdentifier, $itemTypeName),
+            $this->createTestItemType($itemTypeIdentifier, $itemTypeId, $itemTypeName),
             $language,
             $this->createTestItemAttributes(
                 $counter,
@@ -73,10 +90,11 @@ final class DataSourceTestItemCreator
         );
     }
 
-    public function createTestItemType(string $identifier, string $name): ItemTypeInterface
+    public function createTestItemType(string $identifier, int $itemTypeId, string $name): ItemTypeInterface
     {
         return new ItemType(
             $identifier,
+            $itemTypeId,
             $name
         );
     }
@@ -134,19 +152,19 @@ final class DataSourceTestItemCreator
     {
         return $this->createTestItemGroupList(
             $this->createTestItemGroup(
-                self::ARTICLE_IDENTIFIER . '_' . 'en',
+                self::ARTICLE_TYPE_IDENTIFIER . '_' . self::LANGUAGE_EN,
                 $this->createTestItemListForEnglishArticles()
             ),
             $this->createTestItemGroup(
-                self::ARTICLE_IDENTIFIER . '_' . 'de',
+                self::ARTICLE_TYPE_IDENTIFIER . '_' . self::LANGUAGE_DE,
                 $this->createTestItemListForGermanArticles()
             ),
             $this->createTestItemGroup(
-                self::BLOG_IDENTIFIER . '_' . 'en',
+                self::BLOG_TYPE_IDENTIFIER . '_' . self::LANGUAGE_EN,
                 $this->createTestItemListForEnglishBlogPosts()
             ),
             $this->createTestItemGroup(
-                self::BLOG_IDENTIFIER . '_' . 'fr',
+                self::BLOG_TYPE_IDENTIFIER . '_' . self::LANGUAGE_FR,
                 $this->createTestItemListForFrenchBlogPosts()
             ),
         );
@@ -163,16 +181,18 @@ final class DataSourceTestItemCreator
             $this->createTestItem(
                 1,
                 '3',
-                self::ARTICLE_IDENTIFIER,
+                self::ARTICLE_TYPE_ID,
+                self::ARTICLE_TYPE_IDENTIFIER,
                 self::ARTICLE_NAME,
-                'de'
+                self::LANGUAGE_DE
             ),
             $this->createTestItem(
                 2,
                 '4',
-                self::ARTICLE_IDENTIFIER,
+                self::ARTICLE_TYPE_ID,
+                self::ARTICLE_TYPE_IDENTIFIER,
                 self::ARTICLE_NAME,
-                'de'
+                self::LANGUAGE_DE
             ),
         );
     }
@@ -188,23 +208,26 @@ final class DataSourceTestItemCreator
             $this->createTestItem(
                 1,
                 '8',
-                self::BLOG_IDENTIFIER,
-                self::BLOG_IDENTIFIER,
-                'fr'
+                self::BLOG_TYPE_ID,
+                self::BLOG_TYPE_IDENTIFIER,
+                self::BLOG_TYPE_IDENTIFIER,
+                self::LANGUAGE_FR
             ),
             $this->createTestItem(
                 2,
                 '9',
-                self::BLOG_IDENTIFIER,
+                self::BLOG_TYPE_ID,
+                self::BLOG_TYPE_IDENTIFIER,
                 self::BLOG_NAME,
-                'fr'
+                self::LANGUAGE_FR
             ),
             $this->createTestItem(
                 3,
                 '10',
-                self::BLOG_IDENTIFIER,
+                self::BLOG_TYPE_ID,
+                self::BLOG_TYPE_IDENTIFIER,
                 self::BLOG_NAME,
-                'fr'
+                self::LANGUAGE_FR
             ),
         );
     }
@@ -223,16 +246,18 @@ final class DataSourceTestItemCreator
             $this->createTestItem(
                 1,
                 '1',
-                self::ARTICLE_IDENTIFIER,
+                self::ARTICLE_TYPE_ID,
+                self::ARTICLE_TYPE_IDENTIFIER,
                 self::ARTICLE_NAME,
-                'en'
+                self::LANGUAGE_EN
             ),
             $this->createTestItem(
                 2,
                 '2',
-                self::ARTICLE_IDENTIFIER,
+                self::ARTICLE_TYPE_ID,
+                self::ARTICLE_TYPE_IDENTIFIER,
                 self::ARTICLE_NAME,
-                'en'
+                self::LANGUAGE_EN
             ),
         ];
     }
@@ -246,16 +271,18 @@ final class DataSourceTestItemCreator
             $this->createTestItem(
                 1,
                 '3',
-                DataSourceTestItemCreator::ARTICLE_IDENTIFIER,
-                DataSourceTestItemCreator::ARTICLE_NAME,
-                'de'
+                self::ARTICLE_TYPE_ID,
+                self::ARTICLE_TYPE_IDENTIFIER,
+                self::ARTICLE_NAME,
+                self::LANGUAGE_DE
             ),
             $this->createTestItem(
                 2,
                 '4',
-                DataSourceTestItemCreator::ARTICLE_IDENTIFIER,
-                DataSourceTestItemCreator::ARTICLE_NAME,
-                'de'
+                self::ARTICLE_TYPE_ID,
+                self::ARTICLE_TYPE_IDENTIFIER,
+                self::ARTICLE_NAME,
+                self::LANGUAGE_DE
             ),
         ];
     }
@@ -269,23 +296,26 @@ final class DataSourceTestItemCreator
             $this->createTestItem(
                 1,
                 '5',
-                self::BLOG_IDENTIFIER,
+                self::BLOG_TYPE_ID,
+                self::BLOG_TYPE_IDENTIFIER,
                 self::BLOG_NAME,
-                'en'
+                self::LANGUAGE_EN
             ),
             $this->createTestItem(
                 2,
                 '6',
-                self::BLOG_IDENTIFIER,
+                self::BLOG_TYPE_ID,
+                self::BLOG_TYPE_IDENTIFIER,
                 self::BLOG_NAME,
-                'en'
+                self::LANGUAGE_EN
             ),
             $this->createTestItem(
                 3,
                 '7',
-                self::BLOG_IDENTIFIER,
+                self::BLOG_TYPE_ID,
+                self::BLOG_TYPE_IDENTIFIER,
                 self::BLOG_NAME,
-                'en'
+                self::LANGUAGE_EN
             ),
         ];
     }
@@ -303,9 +333,10 @@ final class DataSourceTestItemCreator
             $products[] = $this->createTestItem(
                 $i,
                 (string)$id,
-                self::PRODUCT_IDENTIFIER,
+                self::PRODUCT_TYPE_ID,
+                self::PRODUCT_TYPE_IDENTIFIER,
                 self::PRODUCT_NAME,
-                'en'
+                self::LANGUAGE_EN
             );
         }
 
@@ -328,14 +359,15 @@ final class DataSourceTestItemCreator
     public function getAllTestItemTypeIdentifiers(): array
     {
         return [
-            self::ARTICLE_IDENTIFIER,
-            self::BLOG_IDENTIFIER,
-            self::PRODUCT_IDENTIFIER,
+            self::ARTICLE_TYPE_IDENTIFIER,
+            self::BLOG_TYPE_IDENTIFIER,
+            self::PRODUCT_TYPE_IDENTIFIER,
         ];
     }
 
     /**
      * @phpstan-param array<string, array{
+     *  'item_type_id': int,
      *  'item_type_identifier': string,
      *  'item_type_name': string,
      *  'languages': array,
@@ -360,6 +392,7 @@ final class DataSourceTestItemCreator
 
     /**
      * @phpstan-param array<string, array{
+     *  'item_type_id': int,
      *  'item_type_identifier': string,
      *  'item_type_name': string,
      *  'languages': array,
@@ -374,6 +407,7 @@ final class DataSourceTestItemCreator
 
         foreach ($testItemsConfig as $testItem) {
             $items[] = $this->createTestItemsForGivenLanguages(
+                $testItem['item_type_id'],
                 $testItem['item_type_identifier'],
                 $testItem['item_type_name'],
                 $testItem['languages'],
@@ -390,6 +424,7 @@ final class DataSourceTestItemCreator
      * @return array<\Ibexa\Contracts\Personalization\Value\ItemInterface>
      */
     private function createTestItemsForGivenLanguages(
+        int $itemTypeId,
         string $itemTypeIdentifier,
         string $itemTypeName,
         array $languages,
@@ -402,6 +437,7 @@ final class DataSourceTestItemCreator
                 $items[] = $this->createTestItem(
                     $i,
                     (string)$this->lastGeneratedId,
+                    $itemTypeId,
                     $itemTypeIdentifier,
                     $itemTypeName,
                     $language
@@ -416,6 +452,7 @@ final class DataSourceTestItemCreator
 
     /**
      * @phpstan-return iterable<string, array{
+     *  'item_type_id': int,
      *  'item_type_identifier': string,
      *  'item_type_name': string,
      *  'languages': array<string>,
@@ -425,23 +462,26 @@ final class DataSourceTestItemCreator
     private function getDefaultItemsConfig(): iterable
     {
         yield 'articles' => [
-            'item_type_identifier' => self::ARTICLE_IDENTIFIER,
-            'item_type_name' => 'Article',
-            'languages' => ['en', 'de'],
+            'item_type_id' => self::ARTICLE_TYPE_ID,
+            'item_type_identifier' => self::ARTICLE_TYPE_IDENTIFIER,
+            'item_type_name' => self::ARTICLE_TYPE_NAME,
+            'languages' => [self::LANGUAGE_EN, self::LANGUAGE_DE],
             'limit' => 2,
         ];
 
         yield 'blog posts' => [
-            'item_type_identifier' => self::BLOG_IDENTIFIER,
-            'item_type_name' => 'Blog',
-            'languages' => ['en', 'fr'],
+            'item_type_id' => self::BLOG_TYPE_ID,
+            'item_type_identifier' => self::BLOG_TYPE_IDENTIFIER,
+            'item_type_name' => self::BLOG_TYPE_NAME,
+            'languages' => [self::LANGUAGE_EN, self::LANGUAGE_FR],
             'limit' => 3,
         ];
 
         yield 'products' => [
-            'item_type_identifier' => self::PRODUCT_IDENTIFIER,
-            'item_type_name' => 'Product',
-            'languages' => ['en', 'de', 'fr', 'no'],
+            'item_type_id' => self::PRODUCT_TYPE_ID,
+            'item_type_identifier' => self::PRODUCT_TYPE_IDENTIFIER,
+            'item_type_name' => self::PRODUCT_TYPE_NAME,
+            'languages' => self::ALL_LANGUAGES,
             'limit' => 10,
         ];
     }

--- a/tests/lib/Service/Storage/DataSourceServiceTest.php
+++ b/tests/lib/Service/Storage/DataSourceServiceTest.php
@@ -33,16 +33,17 @@ final class DataSourceServiceTest extends AbstractDataSourceTestCase
         $item = $this->itemCreator->createTestItem(
             1,
             '1',
-            DataSourceTestItemCreator::ARTICLE_IDENTIFIER,
+            DataSourceTestItemCreator::ARTICLE_TYPE_ID,
+            DataSourceTestItemCreator::ARTICLE_TYPE_IDENTIFIER,
             DataSourceTestItemCreator::ARTICLE_NAME,
-            'en'
+            DataSourceTestItemCreator::LANGUAGE_EN
         );
 
         $dataSourceService = new DataSourceService(
             [
                 $this->createDataSourceMockForGetItem(
                     '1',
-                    'en',
+                    DataSourceTestItemCreator::LANGUAGE_EN,
                     $item
                 ),
             ],
@@ -51,7 +52,7 @@ final class DataSourceServiceTest extends AbstractDataSourceTestCase
 
         self::assertEquals(
             $item,
-            $dataSourceService->getItem('1', 'en')
+            $dataSourceService->getItem('1', DataSourceTestItemCreator::LANGUAGE_EN)
         );
     }
 
@@ -85,10 +86,10 @@ final class DataSourceServiceTest extends AbstractDataSourceTestCase
     {
         $criteria = $this->itemCreator->createTestCriteria(
             [
-                DataSourceTestItemCreator::ARTICLE_IDENTIFIER,
-                DataSourceTestItemCreator::PRODUCT_IDENTIFIER,
+                DataSourceTestItemCreator::ARTICLE_TYPE_IDENTIFIER,
+                DataSourceTestItemCreator::PRODUCT_TYPE_IDENTIFIER,
             ],
-            ['en']
+            [DataSourceTestItemCreator::LANGUAGE_EN]
         );
         $products = $this->itemCreator->createTestItemListForEnglishProducts();
         $articles = $this->itemCreator->createTestItemListForEnglishArticles();
@@ -128,10 +129,14 @@ final class DataSourceServiceTest extends AbstractDataSourceTestCase
     {
         $criteria = $this->itemCreator->createTestCriteria(
             [
-                DataSourceTestItemCreator::ARTICLE_IDENTIFIER,
-                DataSourceTestItemCreator::BLOG_IDENTIFIER,
+                DataSourceTestItemCreator::ARTICLE_TYPE_IDENTIFIER,
+                DataSourceTestItemCreator::BLOG_TYPE_IDENTIFIER,
             ],
-            ['en', 'de', 'fr']
+            [
+                DataSourceTestItemCreator::LANGUAGE_EN,
+                DataSourceTestItemCreator::LANGUAGE_DE,
+                DataSourceTestItemCreator::LANGUAGE_FR,
+            ]
         );
 
         $expectedGroupList = $this->itemCreator->createTestItemGroupListForArticlesAndBlogPosts();
@@ -177,10 +182,10 @@ final class DataSourceServiceTest extends AbstractDataSourceTestCase
         yield [
             $this->itemCreator->createTestCriteria(
                 [
-                    DataSourceTestItemCreator::ARTICLE_IDENTIFIER,
-                    DataSourceTestItemCreator::PRODUCT_IDENTIFIER,
+                    DataSourceTestItemCreator::ARTICLE_TYPE_IDENTIFIER,
+                    DataSourceTestItemCreator::PRODUCT_TYPE_IDENTIFIER,
                 ],
-                ['en']
+                [DataSourceTestItemCreator::LANGUAGE_EN]
             ),
             $this->itemCreator->createTestItemListForEnglishArticlesAndProducts(),
         ];
@@ -188,11 +193,11 @@ final class DataSourceServiceTest extends AbstractDataSourceTestCase
         yield [
             $this->itemCreator->createTestCriteria(
                 [
-                    DataSourceTestItemCreator::ARTICLE_IDENTIFIER,
-                    DataSourceTestItemCreator::BLOG_IDENTIFIER,
-                    DataSourceTestItemCreator::PRODUCT_IDENTIFIER,
+                    DataSourceTestItemCreator::ARTICLE_TYPE_IDENTIFIER,
+                    DataSourceTestItemCreator::BLOG_TYPE_IDENTIFIER,
+                    DataSourceTestItemCreator::PRODUCT_TYPE_IDENTIFIER,
                 ],
-                ['en', 'fr', 'de', 'no']
+                DataSourceTestItemCreator::ALL_LANGUAGES
             ),
             $this->createItems(),
         ];

--- a/tests/lib/Storage/AbstractDataSourceTestCase.php
+++ b/tests/lib/Storage/AbstractDataSourceTestCase.php
@@ -29,6 +29,7 @@ abstract class AbstractDataSourceTestCase extends TestCase
 
     /**
      * @phpstan-param ?iterable<string, array{
+     *  'item_type_id': int,
      *  'item_type_identifier': string,
      *  'item_type_name': string,
      *  'languages': array<string>,

--- a/tests/lib/Storage/AbstractItemTestCase.php
+++ b/tests/lib/Storage/AbstractItemTestCase.php
@@ -48,18 +48,18 @@ abstract class AbstractItemTestCase extends AbstractDataSourceTestCase
 
         $counter = 1;
         $articleId = '1';
-        $articleLanguage = 'en';
 
         $this->assertFetchItem(
             $dataSource,
             $articleId,
-            $articleLanguage,
+            DataSourceTestItemCreator::LANGUAGE_EN,
             $this->itemCreator->createTestItem(
                 $counter,
                 $articleId,
-                DataSourceTestItemCreator::ARTICLE_IDENTIFIER,
+                DataSourceTestItemCreator::ARTICLE_TYPE_ID,
+                DataSourceTestItemCreator::ARTICLE_TYPE_IDENTIFIER,
                 DataSourceTestItemCreator::ARTICLE_NAME,
-                $articleLanguage
+                DataSourceTestItemCreator::LANGUAGE_EN,
             )
         );
     }
@@ -77,8 +77,8 @@ abstract class AbstractItemTestCase extends AbstractDataSourceTestCase
         yield [
             $this->itemCreator->createTestCriteria(
                 [
-                    DataSourceTestItemCreator::ARTICLE_IDENTIFIER,
-                    DataSourceTestItemCreator::PRODUCT_IDENTIFIER,
+                    DataSourceTestItemCreator::ARTICLE_TYPE_IDENTIFIER,
+                    DataSourceTestItemCreator::PRODUCT_TYPE_IDENTIFIER,
                 ],
                 ['pl']
             ),
@@ -88,7 +88,7 @@ abstract class AbstractItemTestCase extends AbstractDataSourceTestCase
         yield [
             $this->itemCreator->createTestCriteria(
                 [
-                    DataSourceTestItemCreator::ARTICLE_IDENTIFIER,
+                    DataSourceTestItemCreator::ARTICLE_TYPE_IDENTIFIER,
                 ],
                 ['en']
             ),
@@ -151,7 +151,7 @@ abstract class AbstractItemTestCase extends AbstractDataSourceTestCase
 
         yield [
             $this->itemCreator->createTestCriteria(
-                [DataSourceTestItemCreator::ARTICLE_IDENTIFIER],
+                [DataSourceTestItemCreator::ARTICLE_TYPE_IDENTIFIER],
                 []
             ),
             $this->itemCreator->createTestItemList(),
@@ -160,8 +160,8 @@ abstract class AbstractItemTestCase extends AbstractDataSourceTestCase
         yield [
             $this->itemCreator->createTestCriteria(
                 [
-                    DataSourceTestItemCreator::ARTICLE_IDENTIFIER,
-                    DataSourceTestItemCreator::PRODUCT_IDENTIFIER,
+                    DataSourceTestItemCreator::ARTICLE_TYPE_IDENTIFIER,
+                    DataSourceTestItemCreator::PRODUCT_TYPE_IDENTIFIER,
                 ],
                 ['pl']
             ),
@@ -171,8 +171,8 @@ abstract class AbstractItemTestCase extends AbstractDataSourceTestCase
         yield [
             $this->itemCreator->createTestCriteria(
                 [
-                    DataSourceTestItemCreator::ARTICLE_IDENTIFIER,
-                    DataSourceTestItemCreator::PRODUCT_IDENTIFIER,
+                    DataSourceTestItemCreator::ARTICLE_TYPE_IDENTIFIER,
+                    DataSourceTestItemCreator::PRODUCT_TYPE_IDENTIFIER,
                 ],
                 ['en']
             ),
@@ -188,8 +188,8 @@ abstract class AbstractItemTestCase extends AbstractDataSourceTestCase
         yield [
             $this->itemCreator->createTestCriteria(
                 [
-                    DataSourceTestItemCreator::ARTICLE_IDENTIFIER,
-                    DataSourceTestItemCreator::BLOG_IDENTIFIER,
+                    DataSourceTestItemCreator::ARTICLE_TYPE_IDENTIFIER,
+                    DataSourceTestItemCreator::BLOG_TYPE_IDENTIFIER,
                 ],
                 ['en', 'fr', 'de'],
                 7
@@ -212,8 +212,8 @@ abstract class AbstractItemTestCase extends AbstractDataSourceTestCase
         yield [
             $this->itemCreator->createTestCriteria(
                 [
-                    DataSourceTestItemCreator::ARTICLE_IDENTIFIER,
-                    DataSourceTestItemCreator::BLOG_IDENTIFIER,
+                    DataSourceTestItemCreator::ARTICLE_TYPE_IDENTIFIER,
+                    DataSourceTestItemCreator::BLOG_TYPE_IDENTIFIER,
                 ],
                 ['en', 'fr', 'de'],
                 5,

--- a/tests/lib/Strategy/Storage/GroupByItemTypeAndLanguageStrategyTest.php
+++ b/tests/lib/Strategy/Storage/GroupByItemTypeAndLanguageStrategyTest.php
@@ -31,25 +31,25 @@ final class GroupByItemTypeAndLanguageStrategyTest extends AbstractDataSourceTes
     {
         $criteria = $this->itemCreator->createTestCriteria(
             [
-                DataSourceTestItemCreator::ARTICLE_IDENTIFIER,
-                DataSourceTestItemCreator::BLOG_IDENTIFIER,
+                DataSourceTestItemCreator::ARTICLE_TYPE_IDENTIFIER,
+                DataSourceTestItemCreator::BLOG_TYPE_IDENTIFIER,
             ],
             ['en', 'de', 'fr']
         );
         $criteriaArticlesEn = $this->itemCreator->createTestCriteria(
-            [DataSourceTestItemCreator::ARTICLE_IDENTIFIER],
+            [DataSourceTestItemCreator::ARTICLE_TYPE_IDENTIFIER],
             ['en'],
         );
         $criteriaArticlesDe = $this->itemCreator->createTestCriteria(
-            [DataSourceTestItemCreator::ARTICLE_IDENTIFIER],
+            [DataSourceTestItemCreator::ARTICLE_TYPE_IDENTIFIER],
             ['de'],
         );
         $criteriaBlogPostsEn = $this->itemCreator->createTestCriteria(
-            [DataSourceTestItemCreator::BLOG_IDENTIFIER],
+            [DataSourceTestItemCreator::BLOG_TYPE_IDENTIFIER],
             ['en'],
         );
         $criteriaBlogPostsFr = $this->itemCreator->createTestCriteria(
-            [DataSourceTestItemCreator::BLOG_IDENTIFIER],
+            [DataSourceTestItemCreator::BLOG_TYPE_IDENTIFIER],
             ['fr'],
         );
 

--- a/tests/lib/Strategy/Storage/GroupItemStrategyDispatcherTest.php
+++ b/tests/lib/Strategy/Storage/GroupItemStrategyDispatcherTest.php
@@ -42,8 +42,8 @@ final class GroupItemStrategyDispatcherTest extends AbstractDataSourceTestCase
     {
         $criteria = $this->itemCreator->createTestCriteria(
             [
-                DataSourceTestItemCreator::ARTICLE_IDENTIFIER,
-                DataSourceTestItemCreator::BLOG_IDENTIFIER,
+                DataSourceTestItemCreator::ARTICLE_TYPE_IDENTIFIER,
+                DataSourceTestItemCreator::BLOG_TYPE_IDENTIFIER,
             ],
             ['en', 'de', 'fr']
         );
@@ -66,7 +66,7 @@ final class GroupItemStrategyDispatcherTest extends AbstractDataSourceTestCase
     {
         $criteria = $this->itemCreator->createTestCriteria(
             [
-                DataSourceTestItemCreator::PRODUCT_IDENTIFIER,
+                DataSourceTestItemCreator::PRODUCT_TYPE_IDENTIFIER,
             ],
             ['en']
         );


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-915](https://issues.ibexa.co/browse/IBX-915)
| **Type**                                   | improvement
| **Target Ibexa DXP version** | `v4.0`
| **BC breaks**                          | no
| **Doc needed**                       | no

This PR provides added getId method to ItemTypeInterface which allow to use numeric ids for item types. 

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/php-dev-team`).
