### PR TITLE
IBX-607: Added method 'first' to ItemListInterface

### DIFF
--- a/src/contracts/Value/ItemListInterface.php
+++ b/src/contracts/Value/ItemListInterface.php
@@ -36,7 +36,7 @@ interface ItemListInterface extends Traversable, Countable
     public function slice(int $offset, ?int $length = null): self;
 
     /**
-     * @throws \EzSystems\EzRecommendationClient\Exception\ItemNotFoundException
+     * @throws \OutOfBoundsException
      */
     public function first(): ItemInterface;
 }

--- a/src/contracts/Value/ItemListInterface.php
+++ b/src/contracts/Value/ItemListInterface.php
@@ -34,4 +34,9 @@ interface ItemListInterface extends Traversable, Countable
      * Returns a new ItemInterface collection sliced of $length elements starting at position $offset.
      */
     public function slice(int $offset, ?int $length = null): self;
+
+    /**
+     * @throws \EzSystems\EzRecommendationClient\Exception\ItemNotFoundException
+     */
+    public function first(): ItemInterface;
 }

--- a/src/contracts/Value/ItemListInterface.php
+++ b/src/contracts/Value/ItemListInterface.php
@@ -36,7 +36,7 @@ interface ItemListInterface extends Traversable, Countable
     public function slice(int $offset, ?int $length = null): self;
 
     /**
-     * @throws \OutOfBoundsException
+     * @throws \eZ\Publish\API\Repository\Exceptions\OutOfBoundsException
      */
     public function first(): ItemInterface;
 }

--- a/src/lib/Exception/ItemNotFoundException.php
+++ b/src/lib/Exception/ItemNotFoundException.php
@@ -12,10 +12,16 @@ use Throwable;
 
 final class ItemNotFoundException extends NotFoundException
 {
-    public function __construct(string $itemId, string $language, int $code = 0, Throwable $previous = null)
+    public function __construct(?string $itemId = null, ?string $language = null, int $code = 0, Throwable $previous = null)
     {
+        $message = 'Item not found';
+
+        if (isset($itemId, $language)) {
+            $message .= sprintf(' with id: %s and language: %s', $itemId, $language);
+        }
+
         parent::__construct(
-            sprintf('Item not found with id: %s and language: %s', $itemId, $language),
+            $message,
             $code,
             $previous
         );

--- a/src/lib/Exception/ItemNotFoundException.php
+++ b/src/lib/Exception/ItemNotFoundException.php
@@ -12,16 +12,10 @@ use Throwable;
 
 final class ItemNotFoundException extends NotFoundException
 {
-    public function __construct(?string $itemId = null, ?string $language = null, int $code = 0, Throwable $previous = null)
+    public function __construct(string $itemId, string $language, int $code = 0, Throwable $previous = null)
     {
-        $message = 'Item not found';
-
-        if (isset($itemId, $language)) {
-            $message .= sprintf(' with id: %s and language: %s', $itemId, $language);
-        }
-
         parent::__construct(
-            $message,
+            sprintf('Item not found with id: %s and language: %s', $itemId, $language),
             $code,
             $previous
         );

--- a/src/lib/Value/Storage/ItemList.php
+++ b/src/lib/Value/Storage/ItemList.php
@@ -14,6 +14,7 @@ use EzSystems\EzRecommendationClient\Exception\ItemNotFoundException;
 use Ibexa\Contracts\Personalization\Value\ItemInterface;
 use Ibexa\Contracts\Personalization\Value\ItemListInterface;
 use IteratorAggregate;
+use OutOfBoundsException;
 use Traversable;
 
 /**
@@ -83,7 +84,7 @@ final class ItemList implements IteratorAggregate, ItemListInterface
     public function first(): ItemInterface
     {
         if (empty($this->items)) {
-            throw new ItemNotFoundException();
+            throw new OutOfBoundsException('Collection is empty');
         }
 
         return reset($this->items);

--- a/src/lib/Value/Storage/ItemList.php
+++ b/src/lib/Value/Storage/ItemList.php
@@ -80,6 +80,15 @@ final class ItemList implements IteratorAggregate, ItemListInterface
         return new self(array_slice($this->items, $offset, $length));
     }
 
+    public function first(): ItemInterface
+    {
+        if (empty($this->items)) {
+            throw new ItemNotFoundException();
+        }
+
+        return reset($this->items);
+    }
+
     /**
      * @param \Traversable<\Ibexa\Contracts\Personalization\Value\ItemInterface> $traversable
      */

--- a/src/lib/Value/Storage/ItemList.php
+++ b/src/lib/Value/Storage/ItemList.php
@@ -10,11 +10,11 @@ namespace Ibexa\Personalization\Value\Storage;
 
 use ArrayIterator;
 use Closure;
+use eZ\Publish\API\Repository\Exceptions\OutOfBoundsException;
 use EzSystems\EzRecommendationClient\Exception\ItemNotFoundException;
 use Ibexa\Contracts\Personalization\Value\ItemInterface;
 use Ibexa\Contracts\Personalization\Value\ItemListInterface;
 use IteratorAggregate;
-use OutOfBoundsException;
 use Traversable;
 
 /**

--- a/tests/lib/Value/ItemListTest.php
+++ b/tests/lib/Value/ItemListTest.php
@@ -1,0 +1,72 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\Personalization\Value;
+
+use Ibexa\Contracts\Personalization\Value\ItemInterface;
+use Ibexa\Contracts\Personalization\Value\ItemListInterface;
+use Ibexa\Personalization\Value\Storage\ItemList;
+use Ibexa\Tests\Personalization\Creator\DataSourceTestItemCreator;
+use Ibexa\Tests\Personalization\Storage\AbstractDataSourceTestCase;
+use OutOfBoundsException;
+
+final class ItemListTest extends AbstractDataSourceTestCase
+{
+    public function testThrowExceptionWhenFirstElementNotExists(): void
+    {
+        $this->expectException(OutOfBoundsException::class);
+        $this->expectExceptionMessage('Collection is empty');
+
+        $itemList = new ItemList([]);
+        $itemList->first();
+    }
+
+    /**
+     * @dataProvider provideForTestFirst
+     */
+    public function testFirst(ItemListInterface $itemList, ItemInterface $expectedItem): void
+    {
+        self::assertEquals($expectedItem, $itemList->first());
+    }
+
+    /**
+     * @phpstan-return iterable<array{
+     *  \Ibexa\Contracts\Personalization\Value\ItemListInterface,
+     *  \Ibexa\Contracts\Personalization\Value\ItemInterface
+     * }>
+     */
+    public function provideForTestFirst(): iterable
+    {
+        $firstArticle = $this->itemCreator->createTestItem(
+            1,
+            '1',
+            DataSourceTestItemCreator::ARTICLE_TYPE_ID,
+            DataSourceTestItemCreator::ARTICLE_TYPE_IDENTIFIER,
+            DataSourceTestItemCreator::ARTICLE_NAME,
+            DataSourceTestItemCreator::LANGUAGE_EN,
+        );
+
+        $secondArticle = $this->itemCreator->createTestItem(
+            2,
+            '2',
+            DataSourceTestItemCreator::ARTICLE_TYPE_ID,
+            DataSourceTestItemCreator::ARTICLE_TYPE_IDENTIFIER,
+            DataSourceTestItemCreator::ARTICLE_NAME,
+            DataSourceTestItemCreator::LANGUAGE_EN,
+        );
+
+        yield [
+            $this->itemCreator->createTestItemList($firstArticle),
+            $firstArticle,
+        ];
+        yield [
+            $this->itemCreator->createTestItemList($firstArticle, $secondArticle),
+            $firstArticle,
+        ];
+    }
+}

--- a/tests/lib/Value/ItemListTest.php
+++ b/tests/lib/Value/ItemListTest.php
@@ -23,15 +23,15 @@ final class ItemListTest extends AbstractDataSourceTestCase
     public function testThrowExceptionWhenFirstElementNotExists(): void
     {
         $itemList = new ItemList([]);
-        
+
         $this->expectException(OutOfBoundsException::class);
         $this->expectExceptionMessage('Collection is empty');
-        
+
         $itemList->first();
     }
 
     /**
-     * @dataProvider provideForTestFirst
+     * @dataProvider provideDataForTestFirst
      */
     public function testFirst(ItemListInterface $itemList, ItemInterface $expectedItem): void
     {
@@ -44,7 +44,7 @@ final class ItemListTest extends AbstractDataSourceTestCase
      *  \Ibexa\Contracts\Personalization\Value\ItemInterface
      * }>
      */
-    public function provideForTestFirst(): iterable
+    public function provideDataForTestFirst(): iterable
     {
         $firstArticle = $this->itemCreator->createTestItem(
             1,

--- a/tests/lib/Value/ItemListTest.php
+++ b/tests/lib/Value/ItemListTest.php
@@ -15,6 +15,9 @@ use Ibexa\Tests\Personalization\Creator\DataSourceTestItemCreator;
 use Ibexa\Tests\Personalization\Storage\AbstractDataSourceTestCase;
 use OutOfBoundsException;
 
+/**
+ * @covers \Ibexa\Personalization\Value\Storage\ItemList
+ */
 final class ItemListTest extends AbstractDataSourceTestCase
 {
     public function testThrowExceptionWhenFirstElementNotExists(): void

--- a/tests/lib/Value/ItemListTest.php
+++ b/tests/lib/Value/ItemListTest.php
@@ -22,10 +22,11 @@ final class ItemListTest extends AbstractDataSourceTestCase
 {
     public function testThrowExceptionWhenFirstElementNotExists(): void
     {
+        $itemList = new ItemList([]);
+        
         $this->expectException(OutOfBoundsException::class);
         $this->expectExceptionMessage('Collection is empty');
-
-        $itemList = new ItemList([]);
+        
         $itemList->first();
     }
 


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-607](https://issues.ibexa.co/browse/IBX-607)
| **Type**                                   | improvement
| **Target Ibexa DXP version** | `v4.0`
| **BC breaks**                          | no
| **Doc needed**                       | no

This PR provides added `first` method to `ItemTypeInterface` to get first item from the item list. There is also changed ItemNotFoundException passing `itemId` and `language` arguments are optional now. 

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/php-dev-team`).
