### PR TITLE
IBX-190: Added try/catch block for methods using SearchService::findContent

### DIFF
--- a/src/lib/Storage/ContentDataSource.php
+++ b/src/lib/Storage/ContentDataSource.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace Ibexa\Personalization\Storage;
 
 use eZ\Publish\API\Repository\ContentService;
+use eZ\Publish\API\Repository\Exceptions\InvalidArgumentException;
 use eZ\Publish\API\Repository\Exceptions\NotFoundException;
 use eZ\Publish\API\Repository\Exceptions\UnauthorizedException;
 use eZ\Publish\API\Repository\SearchService;
@@ -22,27 +23,28 @@ use Ibexa\Personalization\Content\DataResolverInterface;
 use Ibexa\Personalization\Value\Storage\Item;
 use Ibexa\Personalization\Value\Storage\ItemList;
 use Ibexa\Personalization\Value\Storage\ItemType;
+use Psr\Log\LoggerInterface;
 
 final class ContentDataSource implements DataSourceInterface
 {
     private SearchService $searchService;
-
     private ContentService $contentService;
-
     private QueryType $queryType;
-
     private DataResolverInterface $dataResolver;
+    private LoggerInterface $logger;
 
     public function __construct(
         SearchService $searchService,
         ContentService $contentService,
         QueryType $queryType,
-        DataResolverInterface $dataResolver
+        DataResolverInterface $dataResolver,
+        LoggerInterface $logger
     ) {
         $this->searchService = $searchService;
         $this->contentService = $contentService;
         $this->queryType = $queryType;
         $this->dataResolver = $dataResolver;
+        $this->logger = $logger;
     }
 
     /**
@@ -50,31 +52,40 @@ final class ContentDataSource implements DataSourceInterface
      */
     public function countItems(CriteriaInterface $criteria): int
     {
-        $query = $this->queryType->getQuery(['criteria' => $criteria]);
-        $query->limit = 0;
-        $languageFilter = ['languages' => $criteria->getLanguages()];
+        try {
+            $query = $this->queryType->getQuery(['criteria' => $criteria]);
+            $query->limit = 0;
+            $languageFilter = ['languages' => $criteria->getLanguages()];
 
-        return $this->searchService->findContent($query, $languageFilter)->totalCount ?? 0;
+            return $this->searchService->findContent($query, $languageFilter)->totalCount ?? 0;
+        } catch (NotFoundException $exception) {
+            $this->logger->error($exception->getMessage());
+
+            return 0;
+        }
     }
 
-    /**
-     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
-     */
     public function fetchItems(CriteriaInterface $criteria): iterable
     {
-        $query = $this->queryType->getQuery(['criteria' => $criteria]);
-        $query->performCount = false;
-        $query->limit = $criteria->getLimit();
-        $query->offset = $criteria->getOffset();
-        $languageFilter = ['languages' => $criteria->getLanguages()];
+        try {
+            $query = $this->queryType->getQuery(['criteria' => $criteria]);
+            $query->performCount = false;
+            $query->limit = $criteria->getLimit();
+            $query->offset = $criteria->getOffset();
+            $languageFilter = ['languages' => $criteria->getLanguages()];
 
-        $items = [];
+            $items = [];
 
-        foreach ($this->searchService->findContent($query, $languageFilter) as $hit) {
-            $items[] = $this->createItem($hit->valueObject);
+            foreach ($this->searchService->findContent($query, $languageFilter) as $hit) {
+                $items[] = $this->createItem($hit->valueObject);
+            }
+
+            return new ItemList($items);
+        } catch (NotFoundException | InvalidArgumentException $exception) {
+            $this->logger->error($exception->getMessage());
+
+            return new ItemList([]);
         }
-
-        return new ItemList($items);
     }
 
     public function fetchItem(string $id, string $language): ItemInterface

--- a/src/lib/Storage/ContentDataSource.php
+++ b/src/lib/Storage/ContentDataSource.php
@@ -28,9 +28,13 @@ use Psr\Log\LoggerInterface;
 final class ContentDataSource implements DataSourceInterface
 {
     private SearchService $searchService;
+
     private ContentService $contentService;
+
     private QueryType $queryType;
+
     private DataResolverInterface $dataResolver;
+
     private LoggerInterface $logger;
 
     public function __construct(

--- a/src/lib/Storage/ContentDataSource.php
+++ b/src/lib/Storage/ContentDataSource.php
@@ -51,9 +51,6 @@ final class ContentDataSource implements DataSourceInterface
         $this->logger = $logger;
     }
 
-    /**
-     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
-     */
     public function countItems(CriteriaInterface $criteria): int
     {
         try {
@@ -62,7 +59,7 @@ final class ContentDataSource implements DataSourceInterface
             $languageFilter = ['languages' => $criteria->getLanguages()];
 
             return $this->searchService->findContent($query, $languageFilter)->totalCount ?? 0;
-        } catch (NotFoundException $exception) {
+        } catch (NotFoundException | InvalidArgumentException $exception) {
             $this->logger->error($exception->getMessage());
 
             return 0;

--- a/tests/lib/Storage/AbstractContentDataSourceTestCase.php
+++ b/tests/lib/Storage/AbstractContentDataSourceTestCase.php
@@ -174,7 +174,7 @@ abstract class AbstractContentDataSourceTestCase extends AbstractDataSourceTestC
     /**
      * @param array<\eZ\Publish\API\Repository\Values\Content\Search\SearchHit> $searchHits
      */
-    protected function configureSearchService(
+    protected function configureSearchServiceToReturnSearchResult(
         Query $query,
         CriteriaInterface $criteria,
         int $expectedCount,

--- a/tests/lib/Storage/AbstractContentDataSourceTestCase.php
+++ b/tests/lib/Storage/AbstractContentDataSourceTestCase.php
@@ -1,0 +1,224 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\Personalization\Storage;
+
+use eZ\Publish\API\Repository\ContentService;
+use eZ\Publish\API\Repository\SearchService;
+use eZ\Publish\API\Repository\Values\Content\Content as ApiContent;
+use eZ\Publish\API\Repository\Values\Content\ContentInfo;
+use eZ\Publish\API\Repository\Values\Content\Language;
+use eZ\Publish\API\Repository\Values\Content\Query;
+use eZ\Publish\API\Repository\Values\Content\Search\SearchHit;
+use eZ\Publish\API\Repository\Values\Content\Search\SearchResult;
+use eZ\Publish\API\Repository\Values\Content\VersionInfo as ApiVersionInfo;
+use eZ\Publish\API\Repository\Values\ContentType\ContentType as ApiContentType;
+use eZ\Publish\Core\QueryType\QueryType;
+use eZ\Publish\Core\Repository\Values\Content\Content;
+use eZ\Publish\Core\Repository\Values\Content\VersionInfo;
+use eZ\Publish\Core\Repository\Values\ContentType\ContentType;
+use Ibexa\Contracts\Personalization\Criteria\CriteriaInterface;
+use Ibexa\Contracts\Personalization\Storage\DataSourceInterface;
+use Ibexa\Personalization\Content\DataResolverInterface;
+use Ibexa\Personalization\Storage\ContentDataSource;
+use Ibexa\Tests\Personalization\Creator\DataSourceTestItemCreator;
+use Psr\Log\LoggerInterface;
+
+abstract class AbstractContentDataSourceTestCase extends AbstractDataSourceTestCase
+{
+    protected const LANGUAGES_NAMES = [
+        DataSourceTestItemCreator::LANGUAGE_EN => 'English',
+        DataSourceTestItemCreator::LANGUAGE_DE => 'German',
+        DataSourceTestItemCreator::LANGUAGE_FR => 'French',
+        DataSourceTestItemCreator::LANGUAGE_NO => 'Norway',
+    ];
+
+    protected DataSourceInterface $contentDataSource;
+
+    /** @var \eZ\Publish\API\Repository\SearchService|mixed|\PHPUnit\Framework\MockObject\MockObject */
+    protected SearchService $searchService;
+
+    /** @var \eZ\Publish\API\Repository\ContentService|mixed|\PHPUnit\Framework\MockObject\MockObject */
+    protected ContentService $contentService;
+
+    /** @var \eZ\Publish\Core\QueryType\QueryType|mixed|\PHPUnit\Framework\MockObject\MockObject */
+    protected QueryType $queryType;
+
+    /** @var \Ibexa\Personalization\Content\DataResolverInterface|mixed|\PHPUnit\Framework\MockObject\MockObject */
+    protected DataResolverInterface $dataResolver;
+
+    /** @var \Psr\Log\LoggerInterface|mixed|\PHPUnit\Framework\MockObject\MockObject */
+    protected LoggerInterface $logger;
+
+    protected function setUp(): void
+    {
+        $this->searchService = $this->createMock(SearchService::class);
+        $this->contentService = $this->createMock(ContentService::class);
+        $this->queryType = $this->createMock(QueryType::class);
+        $this->dataResolver = $this->createMock(DataResolverInterface::class);
+        $this->logger = $this->createMock(LoggerInterface::class);
+
+        $this->contentDataSource = new ContentDataSource(
+            $this->searchService,
+            $this->contentService,
+            $this->queryType,
+            $this->dataResolver,
+            $this->logger
+        );
+    }
+
+    /**
+     * @return array<\eZ\Publish\API\Repository\Values\Content\Search\SearchHit>
+     */
+    protected function createSearchHits(ApiContent ...$contents): array
+    {
+        $searchHits = [];
+
+        foreach ($contents as $content) {
+            $searchHits[] = $this->createSearchHit($content);
+        }
+
+        return $searchHits;
+    }
+
+    protected function createSearchHit(ApiContent $content): SearchHit
+    {
+        return new SearchHit(
+            [
+                'valueObject' => $content,
+            ]
+        );
+    }
+
+    protected function createContent(ApiContentType $contentType, ApiVersionInfo $versionInfo): ApiContent
+    {
+        return new Content(
+            [
+                'contentType' => $contentType,
+                'versionInfo' => $versionInfo,
+            ]
+        );
+    }
+
+    /**
+     * @param array<string, string> $names
+     */
+    protected function createContentType(
+        int $contentTypeId,
+        string $contentTypeIdentifier,
+        string $language,
+        array $names
+    ): ApiContentType {
+        return new ContentType(
+            [
+                'id' => $contentTypeId,
+                'identifier' => $contentTypeIdentifier,
+                'mainLanguageCode' => $language,
+                'names' => $names,
+            ]
+        );
+    }
+
+    protected function createVersionInfo(ContentInfo $contentInfo): ApiVersionInfo
+    {
+        return new VersionInfo(
+            [
+                'contentInfo' => $contentInfo,
+            ]
+        );
+    }
+
+    protected function createContentInfo(int $contentId, string $mainLanguageCode, string $name): ContentInfo
+    {
+        return new ContentInfo(
+            [
+                'id' => $contentId,
+                'mainLanguage' => new Language(
+                    [
+                        'id' => 1,
+                        'languageCode' => $mainLanguageCode,
+                        'name' => $name,
+                    ]
+                ),
+            ]
+        );
+    }
+
+    protected function getQuery(CriteriaInterface $criteria): Query
+    {
+        $query = new Query();
+        $query->filter = new Query\Criterion\LogicalAnd(
+            [
+                new Query\Criterion\Visibility(Query\Criterion\Visibility::VISIBLE),
+                new Query\Criterion\ContentTypeIdentifier($criteria->getItemTypeIdentifiers()),
+            ]
+        );
+
+        return $query;
+    }
+
+    protected function configureQueryTypeToReturnQuery(Query $query, CriteriaInterface $criteria): void
+    {
+        $this->queryType
+            ->expects(self::atLeastOnce())
+            ->method('getQuery')
+            ->with(['criteria' => $criteria])
+            ->willReturn($query);
+    }
+
+    /**
+     * @param array<\eZ\Publish\API\Repository\Values\Content\Search\SearchHit> $searchHits
+     */
+    protected function configureSearchService(
+        Query $query,
+        CriteriaInterface $criteria,
+        int $expectedCount,
+        array $searchHits
+    ): void {
+        $this->searchService
+            ->expects(self::atLeastOnce())
+            ->method('findContent')
+            ->with($query, ['languages' => $criteria->getLanguages()])
+            ->willReturn(
+                new SearchResult(
+                    [
+                        'totalCount' => $expectedCount,
+                        'searchHits' => $searchHits,
+                    ]
+                )
+            );
+    }
+
+    /**
+     * @param array<array{\eZ\Publish\API\Repository\Values\Content\Content, array<string>}> $itemAttributesMap
+     */
+    protected function configureDataResolverToReturnItemAttributes(array $itemAttributesMap): void
+    {
+        if (!empty($itemAttributesMap)) {
+            $this->dataResolver
+                ->expects(self::atLeastOnce())
+                ->method('resolve')
+                ->willReturnMap($itemAttributesMap);
+        }
+    }
+
+    /**
+     * @param array<string> $languages
+     */
+    protected function configureContentServiceToReturnContent(
+        string $itemId,
+        array $languages,
+        ApiContent $content
+    ): void {
+        $this->contentService
+            ->expects(self::once())
+            ->method('loadContent')
+            ->with($itemId, $languages)
+            ->willReturn($content);
+    }
+}

--- a/tests/lib/Storage/ContentDataSourceTest.php
+++ b/tests/lib/Storage/ContentDataSourceTest.php
@@ -16,6 +16,9 @@ use Ibexa\Contracts\Personalization\Value\ItemListInterface;
 use Ibexa\Personalization\Value\Storage\ItemList;
 use Ibexa\Tests\Personalization\Creator\DataSourceTestItemCreator;
 
+/**
+ * @covers \Ibexa\Personalization\Storage\ContentDataSource
+ */
 final class ContentDataSourceTest extends AbstractContentDataSourceTestCase
 {
     /**

--- a/tests/lib/Storage/ContentDataSourceTest.php
+++ b/tests/lib/Storage/ContentDataSourceTest.php
@@ -153,8 +153,8 @@ final class ContentDataSourceTest extends AbstractContentDataSourceTestCase
             [DataSourceTestItemCreator::LANGUAGE_EN, DataSourceTestItemCreator::LANGUAGE_DE]
         );
 
-        yield[$criteria, 0, $this->createSearchHits()];
-        yield[
+        yield [$criteria, 0, $this->createSearchHits()];
+        yield [
             $criteria,
             3,
             $this->createSearchHits(
@@ -185,7 +185,7 @@ final class ContentDataSourceTest extends AbstractContentDataSourceTestCase
         $productEn = $this->createContentProduct(3, DataSourceTestItemCreator::LANGUAGE_EN);
 
         yield [$criteria, new ItemList([]), [], []];
-        yield[
+        yield [
             $criteria,
             $this->itemCreator->createTestItemList(
                 $this->itemCreator->createTestItem(

--- a/tests/lib/Storage/ContentDataSourceTest.php
+++ b/tests/lib/Storage/ContentDataSourceTest.php
@@ -31,7 +31,7 @@ final class ContentDataSourceTest extends AbstractContentDataSourceTestCase
         $query = $this->getQuery($criteria);
         $query->limit = 0;
         $this->configureQueryTypeToReturnQuery($query, $criteria);
-        $this->configureSearchService($query, $criteria, $expectedCount, $searchHits);
+        $this->configureSearchServiceToReturnSearchResult($query, $criteria, $expectedCount, $searchHits);
 
         self::assertEquals(
             $expectedCount,
@@ -80,7 +80,7 @@ final class ContentDataSourceTest extends AbstractContentDataSourceTestCase
         $query = $this->getQuery($criteria);
         $query->limit = $criteria->getLimit();
         $this->configureQueryTypeToReturnQuery($query, $criteria);
-        $this->configureSearchService($query, $criteria, $expectedItems->count(), $searchHits);
+        $this->configureSearchServiceToReturnSearchResult($query, $criteria, $expectedItems->count(), $searchHits);
         $this->configureDataResolverToReturnItemAttributes($contentFieldsMap);
 
         self::assertEquals(

--- a/tests/lib/Storage/ContentDataSourceTest.php
+++ b/tests/lib/Storage/ContentDataSourceTest.php
@@ -1,0 +1,292 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\Personalization\Storage;
+
+use eZ\Publish\API\Repository\Values\Content\Content as ApiContent;
+use eZ\Publish\Core\Base\Exceptions\NotFoundException;
+use EzSystems\EzRecommendationClient\Exception\ItemNotFoundException;
+use Ibexa\Contracts\Personalization\Criteria\CriteriaInterface;
+use Ibexa\Contracts\Personalization\Value\ItemListInterface;
+use Ibexa\Personalization\Value\Storage\ItemList;
+use Ibexa\Tests\Personalization\Creator\DataSourceTestItemCreator;
+
+final class ContentDataSourceTest extends AbstractContentDataSourceTestCase
+{
+    /**
+     * @param array<\eZ\Publish\API\Repository\Values\Content\Search\SearchHit> $searchHits
+     *
+     * @dataProvider provideDataForTestCountItems
+     */
+    public function testCountItems(
+        CriteriaInterface $criteria,
+        int $expectedCount,
+        array $searchHits
+    ): void {
+        $query = $this->getQuery($criteria);
+        $query->limit = 0;
+        $this->configureQueryTypeToReturnQuery($query, $criteria);
+        $this->configureSearchService($query, $criteria, $expectedCount, $searchHits);
+
+        self::assertEquals(
+            $expectedCount,
+            $this->contentDataSource->countItems($criteria)
+        );
+        self::assertCount(
+            $expectedCount,
+            $this->contentDataSource->fetchItems($criteria)
+        );
+    }
+
+    public function testFetchItemsReturnEmptyListWhenNotFoundExceptionIsThrown(): void
+    {
+        $undefinedLanguage = DataSourceTestItemCreator::LANGUAGE_DE;
+        $criteria = $this->itemCreator->createTestCriteria(
+            [DataSourceTestItemCreator::ARTICLE_TYPE_IDENTIFIER],
+            [$undefinedLanguage, DataSourceTestItemCreator::LANGUAGE_EN]
+        );
+        $query = $this->getQuery($criteria);
+        $query->limit = $criteria->getLimit();
+        $this->configureQueryTypeToReturnQuery($query, $criteria);
+        $this->searchService
+            ->expects(self::atLeastOnce())
+            ->method('findContent')
+            ->with($query, ['languages' => $criteria->getLanguages()])
+            ->willThrowException(new NotFoundException('language', $undefinedLanguage));
+
+        self::assertEquals(
+            $this->itemCreator->createTestItemList(),
+            $this->contentDataSource->fetchItems($criteria)
+        );
+    }
+
+    /**
+     * @param array<\eZ\Publish\API\Repository\Values\Content\Search\SearchHit> $searchHits
+     * @param array<array{\eZ\Publish\API\Repository\Values\Content\Content, array<string>}> $contentFieldsMap
+     *
+     * @dataProvider provideDataForTestFetchItems
+     */
+    public function testFetchItems(
+        CriteriaInterface $criteria,
+        ItemListInterface $expectedItems,
+        array $searchHits,
+        array $contentFieldsMap
+    ): void {
+        $query = $this->getQuery($criteria);
+        $query->limit = $criteria->getLimit();
+        $this->configureQueryTypeToReturnQuery($query, $criteria);
+        $this->configureSearchService($query, $criteria, $expectedItems->count(), $searchHits);
+        $this->configureDataResolverToReturnItemAttributes($contentFieldsMap);
+
+        self::assertEquals(
+            $expectedItems,
+            $this->contentDataSource->fetchItems($criteria)
+        );
+    }
+
+    public function testFetchItemThrowItemNotFoundException(): void
+    {
+        $itemId = '10';
+        $language = 'pl';
+
+        $this->expectException(ItemNotFoundException::class);
+        $this->expectExceptionMessage(sprintf('Item not found with id: %s and language: %s', $itemId, $language));
+
+        $this->contentService
+            ->expects(self::once())
+            ->method('loadContent')
+            ->with($itemId, [$language])
+            ->willThrowException(new NotFoundException('content', $itemId));
+
+        $this->contentDataSource->fetchItem($itemId, $language);
+    }
+
+    public function testFetchItem(): void
+    {
+        $itemId = '10';
+        $language = DataSourceTestItemCreator::LANGUAGE_EN;
+        $article = $this->createContentArticle((int)$itemId, $language);
+        $this->configureDataResolverToReturnItemAttributes(
+            [
+                [
+                    $article,
+                    $this->itemCreator->createTestItemAttributes(
+                        1,
+                        DataSourceTestItemCreator::ARTICLE_TYPE_IDENTIFIER,
+                        DataSourceTestItemCreator::ARTICLE_NAME,
+                        DataSourceTestItemCreator::LANGUAGE_EN
+                    ),
+                ],
+            ]
+        );
+        $this->configureContentServiceToReturnContent($itemId, [$language], $article);
+
+        self::assertEquals(
+            $this->itemCreator->createTestItem(
+                1,
+                $itemId,
+                DataSourceTestItemCreator::ARTICLE_TYPE_ID,
+                DataSourceTestItemCreator::ARTICLE_TYPE_IDENTIFIER,
+                DataSourceTestItemCreator::ARTICLE_TYPE_NAME,
+                DataSourceTestItemCreator::LANGUAGE_EN,
+            ),
+            $this->contentDataSource->fetchItem($itemId, $language)
+        );
+    }
+
+    /**
+     * @phpstan-return iterable<array{
+     *  \Ibexa\Contracts\Personalization\Criteria\CriteriaInterface,
+     *  int,
+     *  array<\eZ\Publish\API\Repository\Values\Content\Search\SearchHit>
+     * }>
+     */
+    public function provideDataForTestCountItems(): iterable
+    {
+        $criteria = $this->itemCreator->createTestCriteria(
+            [DataSourceTestItemCreator::ARTICLE_TYPE_IDENTIFIER, DataSourceTestItemCreator::PRODUCT_TYPE_IDENTIFIER],
+            [DataSourceTestItemCreator::LANGUAGE_EN, DataSourceTestItemCreator::LANGUAGE_DE]
+        );
+
+        yield[$criteria, 0, $this->createSearchHits()];
+        yield[
+            $criteria,
+            3,
+            $this->createSearchHits(
+                $this->createContentArticle(1, DataSourceTestItemCreator::LANGUAGE_EN),
+                $this->createContentArticle(2, DataSourceTestItemCreator::LANGUAGE_DE),
+                $this->createContentProduct(3, DataSourceTestItemCreator::LANGUAGE_EN),
+            ),
+        ];
+    }
+
+    /**
+     * @phpstan-return iterable<array{
+     *  \Ibexa\Contracts\Personalization\Criteria\CriteriaInterface,
+     *  \Ibexa\Contracts\Personalization\Value\ItemListInterface,
+     *  array<\eZ\Publish\API\Repository\Values\Content\Search\SearchHit>,
+     *  array<array{\eZ\Publish\API\Repository\Values\Content\Content, array<string>}>
+     * }>
+     */
+    public function provideDataForTestFetchItems(): iterable
+    {
+        $criteria = $this->itemCreator->createTestCriteria(
+            [DataSourceTestItemCreator::ARTICLE_TYPE_IDENTIFIER, DataSourceTestItemCreator::PRODUCT_TYPE_IDENTIFIER],
+            [DataSourceTestItemCreator::LANGUAGE_EN, DataSourceTestItemCreator::LANGUAGE_DE]
+        );
+
+        $articleEn = $this->createContentArticle(1, DataSourceTestItemCreator::LANGUAGE_EN);
+        $articleDe = $this->createContentArticle(2, DataSourceTestItemCreator::LANGUAGE_DE);
+        $productEn = $this->createContentProduct(3, DataSourceTestItemCreator::LANGUAGE_EN);
+
+        yield [$criteria, new ItemList([]), [], []];
+        yield[
+            $criteria,
+            $this->itemCreator->createTestItemList(
+                $this->itemCreator->createTestItem(
+                    1,
+                    '1',
+                    DataSourceTestItemCreator::ARTICLE_TYPE_ID,
+                    DataSourceTestItemCreator::ARTICLE_TYPE_IDENTIFIER,
+                    DataSourceTestItemCreator::ARTICLE_TYPE_NAME,
+                    DataSourceTestItemCreator::LANGUAGE_EN,
+                ),
+                $this->itemCreator->createTestItem(
+                    2,
+                    '2',
+                    DataSourceTestItemCreator::ARTICLE_TYPE_ID,
+                    DataSourceTestItemCreator::ARTICLE_TYPE_IDENTIFIER,
+                    DataSourceTestItemCreator::ARTICLE_TYPE_NAME,
+                    DataSourceTestItemCreator::LANGUAGE_DE,
+                ),
+                $this->itemCreator->createTestItem(
+                    1,
+                    '3',
+                    DataSourceTestItemCreator::PRODUCT_TYPE_ID,
+                    DataSourceTestItemCreator::PRODUCT_TYPE_IDENTIFIER,
+                    DataSourceTestItemCreator::PRODUCT_TYPE_NAME,
+                    DataSourceTestItemCreator::LANGUAGE_EN,
+                ),
+            ),
+            $this->createSearchHits($articleEn, $articleDe, $productEn),
+            [
+                [
+                    $articleEn,
+                    $this->itemCreator->createTestItemAttributes(
+                        1,
+                        DataSourceTestItemCreator::ARTICLE_TYPE_IDENTIFIER,
+                        DataSourceTestItemCreator::ARTICLE_NAME,
+                        DataSourceTestItemCreator::LANGUAGE_EN
+                    ),
+                ],
+                [
+                    $articleDe,
+                    $this->itemCreator->createTestItemAttributes(
+                        2,
+                        DataSourceTestItemCreator::ARTICLE_TYPE_IDENTIFIER,
+                        DataSourceTestItemCreator::ARTICLE_NAME,
+                        DataSourceTestItemCreator::LANGUAGE_DE
+                    ),
+                ],
+                [
+                    $productEn,
+                    $this->itemCreator->createTestItemAttributes(
+                        1,
+                        DataSourceTestItemCreator::PRODUCT_TYPE_IDENTIFIER,
+                        DataSourceTestItemCreator::PRODUCT_NAME,
+                        DataSourceTestItemCreator::LANGUAGE_EN
+                    ),
+                ],
+            ],
+        ];
+    }
+
+    private function createContentArticle(int $contentId, string $language): ApiContent
+    {
+        $articleContentType = $this->createContentType(
+            DataSourceTestItemCreator::ARTICLE_TYPE_ID,
+            DataSourceTestItemCreator::ARTICLE_TYPE_IDENTIFIER,
+            $language,
+            [
+                $language => DataSourceTestItemCreator::ARTICLE_NAME,
+            ]
+        );
+        $articleContentInfo = $this->createContentInfo(
+            $contentId,
+            $language,
+            self::LANGUAGES_NAMES[$language]
+        );
+
+        return $this->createContent(
+            $articleContentType,
+            $this->createVersionInfo($articleContentInfo)
+        );
+    }
+
+    private function createContentProduct(int $contentId, string $language): ApiContent
+    {
+        $articleContentType = $this->createContentType(
+            DataSourceTestItemCreator::PRODUCT_TYPE_ID,
+            DataSourceTestItemCreator::PRODUCT_TYPE_IDENTIFIER,
+            $language,
+            [
+                $language => DataSourceTestItemCreator::PRODUCT_TYPE_NAME,
+            ]
+        );
+        $articleContentInfo = $this->createContentInfo(
+            $contentId,
+            DataSourceTestItemCreator::LANGUAGE_EN,
+            self::LANGUAGES_NAMES[$language]
+        );
+
+        return $this->createContent(
+            $articleContentType,
+            $this->createVersionInfo($articleContentInfo)
+        );
+    }
+}


### PR DESCRIPTION
…ontent

| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-190](https://issues.ibexa.co/browse/IBX-190)
| **Type**                                   | improvement
| **Target Ibexa DXP version** | `v4.0`
| **BC breaks**                          | no
| **Doc needed**                       | no

This PR provides added try/catch block for methods using `SearchService::findContent`. If contents are not found in content repository then fetching data from data sources shouldn't be broken. In case when exception will thrown error message will be logged.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/php-dev-team`).
