### PR TITLE
IBX-929: removed unused DeleteLocationEvent

### DIFF
--- a/src/lib/Event/Subscriber/LocationEventSubscriber.php
+++ b/src/lib/Event/Subscriber/LocationEventSubscriber.php
@@ -10,7 +10,6 @@ namespace EzSystems\EzRecommendationClient\Event\Subscriber;
 
 use eZ\Publish\API\Repository\Events\Location\CopySubtreeEvent;
 use eZ\Publish\API\Repository\Events\Location\CreateLocationEvent;
-use eZ\Publish\API\Repository\Events\Location\DeleteLocationEvent;
 use eZ\Publish\API\Repository\Events\Location\HideLocationEvent;
 use eZ\Publish\API\Repository\Events\Location\MoveSubtreeEvent;
 use eZ\Publish\API\Repository\Events\Location\SwapLocationEvent;
@@ -31,7 +30,6 @@ final class LocationEventSubscriber extends AbstractRepositoryEventSubscriber im
         return [
             CopySubtreeEvent::class => ['onCopySubtree', parent::EVENT_PRIORITY],
             CreateLocationEvent::class => ['onCreateLocation', parent::EVENT_PRIORITY],
-            DeleteLocationEvent::class => ['onDeleteLocation', parent::EVENT_PRIORITY],
             HideLocationEvent::class => ['onHideLocation', parent::EVENT_PRIORITY],
             MoveSubtreeEvent::class => ['onMoveSubtree', parent::EVENT_PRIORITY],
             SwapLocationEvent::class => ['onSwapLocation', parent::EVENT_PRIORITY],
@@ -63,19 +61,6 @@ final class LocationEventSubscriber extends AbstractRepositoryEventSubscriber im
             __METHOD__,
             EventNotification::ACTION_UPDATE,
             $event->getContentInfo()
-        );
-    }
-
-    /**
-     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
-     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
-     */
-    public function onDeleteLocation(DeleteLocationEvent $event): void
-    {
-        $this->updateLocationWithChildren(
-            $event->getLocation(),
-            __METHOD__,
-            EventNotification::ACTION_DELETE,
         );
     }
 

--- a/tests/lib/Event/Subscriber/LocationEventSubscriberTest.php
+++ b/tests/lib/Event/Subscriber/LocationEventSubscriberTest.php
@@ -131,28 +131,6 @@ class LocationEventSubscriberTest extends AbstractRepositoryEventSubscriberTest
         $this->locationEventSubscriber->onCreateLocation($event);
     }
 
-    public function testCallOnDeleteLocationMethod()
-    {
-        $event = $this->createMock(DeleteLocationEvent::class);
-        $event
-            ->expects($this->once())
-            ->method('getLocation')
-            ->willReturn($this->location);
-
-        $this->locationServiceMock
-            ->expects($this->atLeastOnce())
-            ->method('loadLocationChildren')
-            ->with($this->equalTo($this->location))
-            ->willReturn($this->emptyLocationChildren);
-
-        $this->locationServiceMock
-            ->expects($this->atLeastOnce())
-            ->method('loadLocation')
-            ->willReturn($this->location);
-
-        $this->locationEventSubscriber->onDeleteLocation($event);
-    }
-
     public function testCallOnHideLocationMethod()
     {
         $event = $this->createMock(HideLocationEvent::class);


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-929](https://issues.ibexa.co/browse/IBX-929)
| **Type**                                   | bug
| **Target Ibexa DXP version** | `v3.3` 
| **BC breaks**                          | no
| **Doc needed**                       | no

This event was moved from eZ Platform 2.5 but was under review it turned out that in 2.5 nothing was happening anyway when calling it:
a function that is assigned to a slot in 2.5:
https://github.com/ezsystems/ezrecommendation-client/blob/7b4ad6fe40c7a9296184dd287dd2f43c8a1cd0ad/src/lib/Service/SignalSlotService.php#L99
where the function `getContent` return null because content not found:
https://github.com/ezsystems/ezrecommendation-client/blob/7b4ad6fe40c7a9296184dd287dd2f43c8a1cd0ad/src/lib/Service/SignalSlotService.php#L186

finally, the `processSending` function does nothing because $content is set to null:
https://github.com/ezsystems/ezrecommendation-client/blob/7b4ad6fe40c7a9296184dd287dd2f43c8a1cd0ad/src/lib/Service/SignalSlotService.php#L234

After talking to Tomasz, we agreed that this event can be removed in 3.3

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/php-dev-team`).
