### PR TITLE
IBX-924: Fixed LoginListener when user login via JWT

### DIFF
--- a/src/lib/Event/Listener/LoginListener.php
+++ b/src/lib/Event/Listener/LoginListener.php
@@ -64,7 +64,7 @@ final class LoginListener
 
     public function onSecurityInteractiveLogin(InteractiveLoginEvent $event): void
     {
-        if (!$event->getRequest()->get('is_rest_request')) {
+        if ($event->getRequest()->get('is_rest_request')) {
             return;
         }
 


### PR DESCRIPTION
This PR provides fix for `LoginListener::onSecurityInteractiveLogin`. Session shouldn't be started if the request type is a REST request. 