### PR TITLE
IBX-1251: Moved tests to Ibexa\PersonalizationClient namespace

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
     "autoload-dev": {
         "psr-4": {
             "EzSystems\\EzRecommendationClient\\Tests\\": "tests/lib/",
-            "Ibexa\\Tests\\Personalization\\": "tests/lib/"
+            "Ibexa\\Tests\\PersonalizationClient\\": "tests/lib/"
         }
     },
     "scripts": {

--- a/tests/lib/Event/Listener/LoginListenerTest.php
+++ b/tests/lib/Event/Listener/LoginListenerTest.php
@@ -6,7 +6,7 @@
  */
 declare(strict_types=1);
 
-namespace Ibexa\Tests\Personalization\Event\Listener;
+namespace Ibexa\Tests\PersonalizationClient\Event\Listener;
 
 use eZ\Publish\API\Repository\UserService;
 use eZ\Publish\Core\MVC\ConfigResolverInterface;


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-1251](https://issues.ibexa.co/browse/IBX-1251)
| **Type**                                   | improvement
| **Target Ibexa DXP version** | `v3.3.11`
| **BC breaks**                          | no
| **Doc needed**                       | no

Due to namespace conflict during rebranding process all new classess should be moved to `PersonalizationClient` namespace

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/php-dev-team`).
