### PR TITLE
IBX-1251: Moved new classes to Ibexa\PersonalizationClient namespace

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,18 +40,17 @@
         "psr-4": {
             "EzSystems\\EzRecommendationClientBundle\\": "src/bundle/",
             "EzSystems\\EzRecommendationClient\\": "src/lib/",
-            "Ibexa\\Contracts\\Personalization\\": "src/contracts/",
-            "Ibexa\\Personalization\\": "src/lib/",
-            "Ibexa\\Bundle\\Personalization\\": "src/bundle/"
+            "Ibexa\\Contracts\\PersonalizationClient\\": "src/contracts/",
+            "Ibexa\\PersonalizationClient\\": "src/lib/",
+            "Ibexa\\Bundle\\PersonalizationClient\\": "src/bundle/"
         }
     },
     "autoload-dev": {
         "psr-4": {
             "EzSystems\\EzRecommendationClient\\Tests\\": "tests/lib/",
             "Ibexa\\Tests\\PersonalizationClient\\": "tests/lib/",
-            "Ibexa\\Tests\\Personalization\\": "tests/lib/",
-            "Ibexa\\Tests\\Integration\\Personalization\\": "tests/integration/",
-            "Ibexa\\Tests\\Bundle\\Personalization\\": "tests/bundle/"
+            "Ibexa\\Tests\\Integration\\PersonalizationClient\\": "tests/integration/",
+            "Ibexa\\Tests\\Bundle\\PersonalizationClient\\": "tests/bundle/"
         }
     },
     "scripts": {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -541,17 +541,17 @@ parameters:
 			path: src/lib/Exception/InvalidRelationException.php
 
 		-
-			message: "#^Access to an undefined property Ibexa\\\\Personalization\\\\Value\\\\Export\\\\Parameters\\:\\:\\$lang\\.$#"
+			message: "#^Access to an undefined property Ibexa\\\\PersonalizationClient\\\\Value\\\\Export\\\\Parameters\\:\\:\\$lang\\.$#"
 			count: 3
 			path: src/lib/Exporter/Exporter.php
 
 		-
-			message: "#^Access to an undefined property Ibexa\\\\Personalization\\\\Value\\\\Export\\\\Parameters\\:\\:\\$page\\.$#"
+			message: "#^Access to an undefined property Ibexa\\\\PersonalizationClient\\\\Value\\\\Export\\\\Parameters\\:\\:\\$page\\.$#"
 			count: 2
 			path: src/lib/Exporter/Exporter.php
 
 		-
-			message: "#^Call to an undefined method Ibexa\\\\Personalization\\\\Value\\\\Export\\\\Parameters\\:\\:getProperties\\(\\)\\.$#"
+			message: "#^Call to an undefined method Ibexa\\\\PersonalizationClient\\\\Value\\\\Export\\\\Parameters\\:\\:getProperties\\(\\)\\.$#"
 			count: 1
 			path: src/lib/Exporter/Exporter.php
 
@@ -571,7 +571,7 @@ parameters:
 			path: src/lib/Exporter/Exporter.php
 
 		-
-			message: "#^Parameter \\#2 \\$parameters of method EzSystems\\\\EzRecommendationClient\\\\Service\\\\ContentServiceInterface\\:\\:fetchContent\\(\\) expects EzSystems\\\\EzRecommendationClient\\\\Value\\\\ExportParameters, Ibexa\\\\Personalization\\\\Value\\\\Export\\\\Parameters given\\.$#"
+			message: "#^Parameter \\#2 \\$parameters of method EzSystems\\\\EzRecommendationClient\\\\Service\\\\ContentServiceInterface\\:\\:fetchContent\\(\\) expects EzSystems\\\\EzRecommendationClient\\\\Value\\\\ExportParameters, Ibexa\\\\PersonalizationClient\\\\Value\\\\Export\\\\Parameters given\\.$#"
 			count: 1
 			path: src/lib/Exporter/Exporter.php
 

--- a/src/bundle/Command/ExportCommand.php
+++ b/src/bundle/Command/ExportCommand.php
@@ -6,13 +6,13 @@
  */
 declare(strict_types=1);
 
-namespace Ibexa\Bundle\Personalization\Command;
+namespace Ibexa\Bundle\PersonalizationClient\Command;
 
 use eZ\Bundle\EzPublishCoreBundle\Command\BackwardCompatibleCommand;
 use EzSystems\EzRecommendationClient\Http\HttpEnvironmentInterface;
 use EzSystems\EzRecommendationClient\Service\ExportServiceInterface;
-use Ibexa\Personalization\Export\Input\CommandInputResolverInterface;
-use Ibexa\Personalization\Factory\Export\ParametersFactoryInterface;
+use Ibexa\PersonalizationClient\Export\Input\CommandInputResolverInterface;
+use Ibexa\PersonalizationClient\Factory\Export\ParametersFactoryInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;

--- a/src/bundle/DependencyInjection/EzRecommendationClientExtension.php
+++ b/src/bundle/DependencyInjection/EzRecommendationClientExtension.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 namespace EzSystems\EzRecommendationClientBundle\DependencyInjection;
 
 use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\SiteAccessAware\ConfigurationProcessor;
-use Ibexa\Contracts\Personalization\Storage\DataSourceInterface;
+use Ibexa\Contracts\PersonalizationClient\Storage\DataSourceInterface;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader;

--- a/src/bundle/Resources/config/services/commands.yaml
+++ b/src/bundle/Resources/config/services/commands.yaml
@@ -4,7 +4,7 @@ services:
         autoconfigure: true
         public: false
 
-    Ibexa\Bundle\Personalization\Command\ExportCommand:
+    Ibexa\Bundle\PersonalizationClient\Command\ExportCommand:
         tags:
             - { name: console.command }
             - { name: monolog.logger, channel: ibexa-recommendation }

--- a/src/bundle/Resources/config/services/contents.yaml
+++ b/src/bundle/Resources/config/services/contents.yaml
@@ -4,7 +4,7 @@ services:
         autoconfigure: true
         public: false
 
-    Ibexa\Personalization\Content\DataResolver: ~
+    Ibexa\PersonalizationClient\Content\DataResolver: ~
 
-    Ibexa\Personalization\Content\DataResolverInterface:
-        '@Ibexa\Personalization\Content\DataResolver'
+    Ibexa\PersonalizationClient\Content\DataResolverInterface:
+        '@Ibexa\PersonalizationClient\Content\DataResolver'

--- a/src/bundle/Resources/config/services/export.yaml
+++ b/src/bundle/Resources/config/services/export.yaml
@@ -4,7 +4,7 @@ services:
         autoconfigure: true
         public: false
 
-    Ibexa\Personalization\Export\Input\CommandInputResolver: ~
+    Ibexa\PersonalizationClient\Export\Input\CommandInputResolver: ~
 
-    Ibexa\Personalization\Export\Input\CommandInputResolverInterface:
-        '@Ibexa\Personalization\Export\Input\CommandInputResolver'
+    Ibexa\PersonalizationClient\Export\Input\CommandInputResolverInterface:
+        '@Ibexa\PersonalizationClient\Export\Input\CommandInputResolver'

--- a/src/bundle/Resources/config/services/factory.yaml
+++ b/src/bundle/Resources/config/services/factory.yaml
@@ -16,10 +16,10 @@ services:
     EzSystems\EzRecommendationClient\Factory\TokenFactoryInterface:
         '@EzSystems\EzRecommendationClient\Factory\TokenFactory'
 
-    Ibexa\Personalization\Factory\Export\ParametersFactory:
+    Ibexa\PersonalizationClient\Factory\Export\ParametersFactory:
         arguments:
             $siteAccessService: '@ezpublish.siteaccess_service'
             $credentialsResolver: '@EzSystems\EzRecommendationClient\Config\EzRecommendationClientCredentialsResolver'
 
-    Ibexa\Personalization\Factory\Export\ParametersFactoryInterface:
-        '@Ibexa\Personalization\Factory\Export\ParametersFactory'
+    Ibexa\PersonalizationClient\Factory\Export\ParametersFactoryInterface:
+        '@Ibexa\PersonalizationClient\Factory\Export\ParametersFactory'

--- a/src/bundle/Resources/config/services/query_types.yaml
+++ b/src/bundle/Resources/config/services/query_types.yaml
@@ -4,6 +4,6 @@ services:
         autoconfigure: true
         public: false
 
-    Ibexa\Personalization\QueryType\ContentDataSourceQueryType:
+    Ibexa\PersonalizationClient\QueryType\ContentDataSourceQueryType:
         tags:
             - { name: ezplatform.query_type }

--- a/src/bundle/Resources/config/services/services.yaml
+++ b/src/bundle/Resources/config/services/services.yaml
@@ -37,9 +37,9 @@ services:
             $clientCredentials: '@EzSystems\EzRecommendationClient\Config\EzRecommendationClientCredentialsResolver'
             $exportCredentials: '@EzSystems\EzRecommendationClient\Config\ExportCredentialsResolver'
 
-    Ibexa\Personalization\Service\Storage\DataSourceService:
+    Ibexa\PersonalizationClient\Service\Storage\DataSourceService:
         arguments:
             $sources: !tagged_iterator ibexa.personalization.data_source
 
-    Ibexa\Personalization\Service\Storage\DataSourceServiceInterface:
-        '@Ibexa\Personalization\Service\Storage\DataSourceService'
+    Ibexa\PersonalizationClient\Service\Storage\DataSourceServiceInterface:
+        '@Ibexa\PersonalizationClient\Service\Storage\DataSourceService'

--- a/src/bundle/Resources/config/services/storages.yaml
+++ b/src/bundle/Resources/config/services/storages.yaml
@@ -4,6 +4,6 @@ services:
         autoconfigure: true
         public: false
 
-    Ibexa\Personalization\Storage\ContentDataSource:
+    Ibexa\PersonalizationClient\Storage\ContentDataSource:
         arguments:
-            $queryType: '@Ibexa\Personalization\QueryType\ContentDataSourceQueryType'
+            $queryType: '@Ibexa\PersonalizationClient\QueryType\ContentDataSourceQueryType'

--- a/src/contracts/Criteria/CriteriaInterface.php
+++ b/src/contracts/Criteria/CriteriaInterface.php
@@ -6,7 +6,7 @@
  */
 declare(strict_types=1);
 
-namespace Ibexa\Contracts\Personalization\Criteria;
+namespace Ibexa\Contracts\PersonalizationClient\Criteria;
 
 interface CriteriaInterface
 {

--- a/src/contracts/Storage/DataSourceInterface.php
+++ b/src/contracts/Storage/DataSourceInterface.php
@@ -6,15 +6,15 @@
  */
 declare(strict_types=1);
 
-namespace Ibexa\Contracts\Personalization\Storage;
+namespace Ibexa\Contracts\PersonalizationClient\Storage;
 
-use Ibexa\Contracts\Personalization\Criteria\CriteriaInterface;
-use Ibexa\Contracts\Personalization\Value\ItemInterface;
+use Ibexa\Contracts\PersonalizationClient\Criteria\CriteriaInterface;
+use Ibexa\Contracts\PersonalizationClient\Value\ItemInterface;
 
 interface DataSourceInterface
 {
     /**
-     * @return iterable<\Ibexa\Contracts\Personalization\Value\ItemInterface>
+     * @return iterable<\Ibexa\Contracts\PersonalizationClient\Value\ItemInterface>
      */
     public function fetchItems(CriteriaInterface $criteria): iterable;
 

--- a/src/contracts/Value/ItemGroupInterface.php
+++ b/src/contracts/Value/ItemGroupInterface.php
@@ -6,7 +6,7 @@
  */
 declare(strict_types=1);
 
-namespace Ibexa\Contracts\Personalization\Value;
+namespace Ibexa\Contracts\PersonalizationClient\Value;
 
 interface ItemGroupInterface
 {

--- a/src/contracts/Value/ItemGroupListInterface.php
+++ b/src/contracts/Value/ItemGroupListInterface.php
@@ -6,18 +6,18 @@
  */
 declare(strict_types=1);
 
-namespace Ibexa\Contracts\Personalization\Value;
+namespace Ibexa\Contracts\PersonalizationClient\Value;
 
 use Countable;
 use Traversable;
 
 /**
- * @extends Traversable<\Ibexa\Contracts\Personalization\Value\ItemGroupInterface>
+ * @extends Traversable<\Ibexa\Contracts\PersonalizationClient\Value\ItemGroupInterface>
  */
 interface ItemGroupListInterface extends Traversable, Countable
 {
     /**
-     * @return iterable<\Ibexa\Contracts\Personalization\Value\ItemGroupInterface>
+     * @return iterable<\Ibexa\Contracts\PersonalizationClient\Value\ItemGroupInterface>
      */
     public function getGroups(): iterable;
 }

--- a/src/contracts/Value/ItemInterface.php
+++ b/src/contracts/Value/ItemInterface.php
@@ -6,7 +6,7 @@
  */
 declare(strict_types=1);
 
-namespace Ibexa\Contracts\Personalization\Value;
+namespace Ibexa\Contracts\PersonalizationClient\Value;
 
 interface ItemInterface
 {

--- a/src/contracts/Value/ItemListInterface.php
+++ b/src/contracts/Value/ItemListInterface.php
@@ -6,13 +6,13 @@
  */
 declare(strict_types=1);
 
-namespace Ibexa\Contracts\Personalization\Value;
+namespace Ibexa\Contracts\PersonalizationClient\Value;
 
 use Countable;
 use Traversable;
 
 /**
- * @extends Traversable<\Ibexa\Contracts\Personalization\Value\ItemInterface>
+ * @extends Traversable<\Ibexa\Contracts\PersonalizationClient\Value\ItemInterface>
  */
 interface ItemListInterface extends Traversable, Countable
 {
@@ -26,7 +26,7 @@ interface ItemListInterface extends Traversable, Countable
     /**
      * Returns a new ItemInterface collection containing matched elements.
      *
-     * @phpstan-param callable(\Ibexa\Contracts\Personalization\Value\ItemInterface=): bool $predicate
+     * @phpstan-param callable(\Ibexa\Contracts\PersonalizationClient\Value\ItemInterface=): bool $predicate
      */
     public function filter(callable $predicate): self;
 

--- a/src/contracts/Value/ItemTypeInterface.php
+++ b/src/contracts/Value/ItemTypeInterface.php
@@ -6,7 +6,7 @@
  */
 declare(strict_types=1);
 
-namespace Ibexa\Contracts\Personalization\Value;
+namespace Ibexa\Contracts\PersonalizationClient\Value;
 
 interface ItemTypeInterface
 {

--- a/src/lib/Content/DataResolver.php
+++ b/src/lib/Content/DataResolver.php
@@ -6,7 +6,7 @@
  */
 declare(strict_types=1);
 
-namespace Ibexa\Personalization\Content;
+namespace Ibexa\PersonalizationClient\Content;
 
 use eZ\Publish\API\Repository\Values\Content\Content;
 

--- a/src/lib/Content/DataResolverInterface.php
+++ b/src/lib/Content/DataResolverInterface.php
@@ -6,7 +6,7 @@
  */
 declare(strict_types=1);
 
-namespace Ibexa\Personalization\Content;
+namespace Ibexa\PersonalizationClient\Content;
 
 use eZ\Publish\API\Repository\Values\Content\Content;
 

--- a/src/lib/Criteria/Criteria.php
+++ b/src/lib/Criteria/Criteria.php
@@ -6,9 +6,9 @@
  */
 declare(strict_types=1);
 
-namespace Ibexa\Personalization\Criteria;
+namespace Ibexa\PersonalizationClient\Criteria;
 
-use Ibexa\Contracts\Personalization\Criteria\CriteriaInterface;
+use Ibexa\Contracts\PersonalizationClient\Criteria\CriteriaInterface;
 
 final class Criteria implements CriteriaInterface
 {

--- a/src/lib/Exception/MissingExportParameterException.php
+++ b/src/lib/Exception/MissingExportParameterException.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
 
 namespace EzSystems\EzRecommendationClient\Exception;
 
-use Ibexa\Personalization\Factory\Export\ParametersFactoryInterface;
+use Ibexa\PersonalizationClient\Factory\Export\ParametersFactoryInterface;
 use Throwable;
 
 final class MissingExportParameterException extends ExportException

--- a/src/lib/Export/Input/CommandInputResolver.php
+++ b/src/lib/Export/Input/CommandInputResolver.php
@@ -6,7 +6,7 @@
  */
 declare(strict_types=1);
 
-namespace Ibexa\Personalization\Export\Input;
+namespace Ibexa\PersonalizationClient\Export\Input;
 
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Input\InputInterface;

--- a/src/lib/Export/Input/CommandInputResolverInterface.php
+++ b/src/lib/Export/Input/CommandInputResolverInterface.php
@@ -6,7 +6,7 @@
  */
 declare(strict_types=1);
 
-namespace Ibexa\Personalization\Export\Input;
+namespace Ibexa\PersonalizationClient\Export\Input;
 
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Input\InputInterface;

--- a/src/lib/Exporter/Exporter.php
+++ b/src/lib/Exporter/Exporter.php
@@ -13,7 +13,7 @@ use eZ\Publish\API\Repository\Repository;
 use EzSystems\EzRecommendationClient\File\ExportFileGenerator;
 use EzSystems\EzRecommendationClient\Helper\ContentHelper;
 use EzSystems\EzRecommendationClient\Service\ContentServiceInterface;
-use Ibexa\Personalization\Value\Export\Parameters;
+use Ibexa\PersonalizationClient\Value\Export\Parameters;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 

--- a/src/lib/Exporter/ExporterInterface.php
+++ b/src/lib/Exporter/ExporterInterface.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
 
 namespace EzSystems\EzRecommendationClient\Exporter;
 
-use Ibexa\Personalization\Value\Export\Parameters;
+use Ibexa\PersonalizationClient\Value\Export\Parameters;
 use Symfony\Component\Console\Output\OutputInterface;
 
 interface ExporterInterface

--- a/src/lib/Factory/Export/ParametersFactory.php
+++ b/src/lib/Factory/Export/ParametersFactory.php
@@ -6,7 +6,7 @@
  */
 declare(strict_types=1);
 
-namespace Ibexa\Personalization\Factory\Export;
+namespace Ibexa\PersonalizationClient\Factory\Export;
 
 use eZ\Publish\Core\MVC\ConfigResolverInterface;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess\SiteAccessServiceInterface;
@@ -15,7 +15,7 @@ use EzSystems\EzRecommendationClient\Config\CredentialsResolverInterface;
 use EzSystems\EzRecommendationClient\Exception\CredentialsNotFoundException;
 use EzSystems\EzRecommendationClient\Exception\InvalidArgumentException;
 use EzSystems\EzRecommendationClient\Exception\MissingExportParameterException;
-use Ibexa\Personalization\Value\Export\Parameters;
+use Ibexa\PersonalizationClient\Value\Export\Parameters;
 
 final class ParametersFactory implements ParametersFactoryInterface
 {

--- a/src/lib/Factory/Export/ParametersFactoryInterface.php
+++ b/src/lib/Factory/Export/ParametersFactoryInterface.php
@@ -6,9 +6,9 @@
  */
 declare(strict_types=1);
 
-namespace Ibexa\Personalization\Factory\Export;
+namespace Ibexa\PersonalizationClient\Factory\Export;
 
-use Ibexa\Personalization\Value\Export\Parameters;
+use Ibexa\PersonalizationClient\Value\Export\Parameters;
 
 interface ParametersFactoryInterface
 {

--- a/src/lib/QueryType/ContentDataSourceQueryType.php
+++ b/src/lib/QueryType/ContentDataSourceQueryType.php
@@ -6,11 +6,11 @@
  */
 declare(strict_types=1);
 
-namespace Ibexa\Personalization\QueryType;
+namespace Ibexa\PersonalizationClient\QueryType;
 
 use eZ\Publish\API\Repository\Values\Content\Query;
 use eZ\Publish\Core\QueryType\OptionsResolverBasedQueryType;
-use Ibexa\Contracts\Personalization\Criteria\CriteriaInterface;
+use Ibexa\Contracts\PersonalizationClient\Criteria\CriteriaInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 final class ContentDataSourceQueryType extends OptionsResolverBasedQueryType

--- a/src/lib/Service/ExportNotificationService.php
+++ b/src/lib/Service/ExportNotificationService.php
@@ -11,7 +11,7 @@ namespace EzSystems\EzRecommendationClient\Service;
 use EzSystems\EzRecommendationClient\Request\ExportNotifierRequest;
 use EzSystems\EzRecommendationClient\SPI\Notification;
 use EzSystems\EzRecommendationClient\Value\ExportNotification;
-use Ibexa\Personalization\Value\Export\Parameters;
+use Ibexa\PersonalizationClient\Value\Export\Parameters;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 

--- a/src/lib/Service/ExportService.php
+++ b/src/lib/Service/ExportService.php
@@ -11,7 +11,7 @@ namespace EzSystems\EzRecommendationClient\Service;
 use EzSystems\EzRecommendationClient\Config\CredentialsResolverInterface;
 use EzSystems\EzRecommendationClient\Exporter\ExporterInterface;
 use EzSystems\EzRecommendationClient\File\FileManagerInterface;
-use Ibexa\Personalization\Value\Export\Parameters;
+use Ibexa\PersonalizationClient\Value\Export\Parameters;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 

--- a/src/lib/Service/ExportServiceInterface.php
+++ b/src/lib/Service/ExportServiceInterface.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
 
 namespace EzSystems\EzRecommendationClient\Service;
 
-use Ibexa\Personalization\Value\Export\Parameters;
+use Ibexa\PersonalizationClient\Value\Export\Parameters;
 use Symfony\Component\Console\Output\OutputInterface;
 
 interface ExportServiceInterface

--- a/src/lib/Service/Storage/DataSourceService.php
+++ b/src/lib/Service/Storage/DataSourceService.php
@@ -6,25 +6,25 @@
  */
 declare(strict_types=1);
 
-namespace Ibexa\Personalization\Service\Storage;
+namespace Ibexa\PersonalizationClient\Service\Storage;
 
 use EzSystems\EzRecommendationClient\Exception\ItemNotFoundException;
 use EzSystems\EzRecommendationClient\Strategy\Storage\GroupItemStrategyDispatcherInterface;
-use Ibexa\Contracts\Personalization\Criteria\CriteriaInterface;
-use Ibexa\Contracts\Personalization\Value\ItemGroupListInterface;
-use Ibexa\Contracts\Personalization\Value\ItemInterface;
-use Ibexa\Contracts\Personalization\Value\ItemListInterface;
-use Ibexa\Personalization\Value\Storage\ItemGroupList;
-use Ibexa\Personalization\Value\Storage\ItemList;
+use Ibexa\Contracts\PersonalizationClient\Criteria\CriteriaInterface;
+use Ibexa\Contracts\PersonalizationClient\Value\ItemGroupListInterface;
+use Ibexa\Contracts\PersonalizationClient\Value\ItemInterface;
+use Ibexa\Contracts\PersonalizationClient\Value\ItemListInterface;
+use Ibexa\PersonalizationClient\Value\Storage\ItemGroupList;
+use Ibexa\PersonalizationClient\Value\Storage\ItemList;
 
 final class DataSourceService implements DataSourceServiceInterface
 {
-    /** @var iterable<\Ibexa\Contracts\Personalization\Storage\DataSourceInterface> */
+    /** @var iterable<\Ibexa\Contracts\PersonalizationClient\Storage\DataSourceInterface> */
     private iterable $sources;
 
     private GroupItemStrategyDispatcherInterface $groupItemStrategyDispatcher;
 
-    /** @param iterable<\Ibexa\Contracts\Personalization\Storage\DataSourceInterface> $sources */
+    /** @param iterable<\Ibexa\Contracts\PersonalizationClient\Storage\DataSourceInterface> $sources */
     public function __construct(
         iterable $sources,
         GroupItemStrategyDispatcherInterface $groupItemStrategyDispatcher

--- a/src/lib/Service/Storage/DataSourceServiceInterface.php
+++ b/src/lib/Service/Storage/DataSourceServiceInterface.php
@@ -6,12 +6,12 @@
  */
 declare(strict_types=1);
 
-namespace Ibexa\Personalization\Service\Storage;
+namespace Ibexa\PersonalizationClient\Service\Storage;
 
-use Ibexa\Contracts\Personalization\Criteria\CriteriaInterface;
-use Ibexa\Contracts\Personalization\Value\ItemGroupListInterface;
-use Ibexa\Contracts\Personalization\Value\ItemInterface;
-use Ibexa\Contracts\Personalization\Value\ItemListInterface;
+use Ibexa\Contracts\PersonalizationClient\Criteria\CriteriaInterface;
+use Ibexa\Contracts\PersonalizationClient\Value\ItemGroupListInterface;
+use Ibexa\Contracts\PersonalizationClient\Value\ItemInterface;
+use Ibexa\Contracts\PersonalizationClient\Value\ItemListInterface;
 
 /**
  * @internal

--- a/src/lib/Storage/ContentDataSource.php
+++ b/src/lib/Storage/ContentDataSource.php
@@ -6,7 +6,7 @@
  */
 declare(strict_types=1);
 
-namespace Ibexa\Personalization\Storage;
+namespace Ibexa\PersonalizationClient\Storage;
 
 use eZ\Publish\API\Repository\ContentService;
 use eZ\Publish\API\Repository\Exceptions\InvalidArgumentException;
@@ -16,13 +16,13 @@ use eZ\Publish\API\Repository\SearchService;
 use eZ\Publish\API\Repository\Values\Content\Content;
 use eZ\Publish\Core\QueryType\QueryType;
 use EzSystems\EzRecommendationClient\Exception\ItemNotFoundException;
-use Ibexa\Contracts\Personalization\Criteria\CriteriaInterface;
-use Ibexa\Contracts\Personalization\Storage\DataSourceInterface;
-use Ibexa\Contracts\Personalization\Value\ItemInterface;
-use Ibexa\Personalization\Content\DataResolverInterface;
-use Ibexa\Personalization\Value\Storage\Item;
-use Ibexa\Personalization\Value\Storage\ItemList;
-use Ibexa\Personalization\Value\Storage\ItemType;
+use Ibexa\Contracts\PersonalizationClient\Criteria\CriteriaInterface;
+use Ibexa\Contracts\PersonalizationClient\Storage\DataSourceInterface;
+use Ibexa\Contracts\PersonalizationClient\Value\ItemInterface;
+use Ibexa\PersonalizationClient\Content\DataResolverInterface;
+use Ibexa\PersonalizationClient\Value\Storage\Item;
+use Ibexa\PersonalizationClient\Value\Storage\ItemList;
+use Ibexa\PersonalizationClient\Value\Storage\ItemType;
 use Psr\Log\LoggerInterface;
 
 final class ContentDataSource implements DataSourceInterface

--- a/src/lib/Storage/InMemoryDataSource.php
+++ b/src/lib/Storage/InMemoryDataSource.php
@@ -9,10 +9,10 @@ declare(strict_types=1);
 namespace EzSystems\EzRecommendationClient\Storage;
 
 use Closure;
-use Ibexa\Contracts\Personalization\Criteria\CriteriaInterface;
-use Ibexa\Contracts\Personalization\Storage\DataSourceInterface;
-use Ibexa\Contracts\Personalization\Value\ItemInterface;
-use Ibexa\Contracts\Personalization\Value\ItemListInterface;
+use Ibexa\Contracts\PersonalizationClient\Criteria\CriteriaInterface;
+use Ibexa\Contracts\PersonalizationClient\Storage\DataSourceInterface;
+use Ibexa\Contracts\PersonalizationClient\Value\ItemInterface;
+use Ibexa\Contracts\PersonalizationClient\Value\ItemListInterface;
 
 final class InMemoryDataSource implements DataSourceInterface
 {

--- a/src/lib/Strategy/Storage/GroupByItemTypeAndLanguageStrategy.php
+++ b/src/lib/Strategy/Storage/GroupByItemTypeAndLanguageStrategy.php
@@ -8,15 +8,15 @@ declare(strict_types=1);
 
 namespace EzSystems\EzRecommendationClient\Strategy\Storage;
 
-use Ibexa\Contracts\Personalization\Criteria\CriteriaInterface;
-use Ibexa\Contracts\Personalization\Storage\DataSourceInterface;
-use Ibexa\Contracts\Personalization\Value\ItemGroupListInterface;
-use Ibexa\Contracts\Personalization\Value\ItemListInterface;
-use Ibexa\Personalization\Criteria\Criteria;
-use Ibexa\Personalization\Strategy\Storage\SupportedGroupItemStrategy;
-use Ibexa\Personalization\Value\Storage\ItemGroup;
-use Ibexa\Personalization\Value\Storage\ItemGroupList;
-use Ibexa\Personalization\Value\Storage\ItemList;
+use Ibexa\Contracts\PersonalizationClient\Criteria\CriteriaInterface;
+use Ibexa\Contracts\PersonalizationClient\Storage\DataSourceInterface;
+use Ibexa\Contracts\PersonalizationClient\Value\ItemGroupListInterface;
+use Ibexa\Contracts\PersonalizationClient\Value\ItemListInterface;
+use Ibexa\PersonalizationClient\Criteria\Criteria;
+use Ibexa\PersonalizationClient\Strategy\Storage\SupportedGroupItemStrategy;
+use Ibexa\PersonalizationClient\Value\Storage\ItemGroup;
+use Ibexa\PersonalizationClient\Value\Storage\ItemGroupList;
+use Ibexa\PersonalizationClient\Value\Storage\ItemList;
 
 final class GroupByItemTypeAndLanguageStrategy implements GroupItemStrategyInterface
 {
@@ -51,7 +51,7 @@ final class GroupByItemTypeAndLanguageStrategy implements GroupItemStrategyInter
     }
 
     /**
-     * @param iterable<\Ibexa\Contracts\Personalization\Value\ItemInterface> $items
+     * @param iterable<\Ibexa\Contracts\PersonalizationClient\Value\ItemInterface> $items
      */
     private function getItemList(iterable $items): ItemListInterface
     {

--- a/src/lib/Strategy/Storage/GroupItemStrategyDispatcher.php
+++ b/src/lib/Strategy/Storage/GroupItemStrategyDispatcher.php
@@ -9,9 +9,9 @@ declare(strict_types=1);
 namespace EzSystems\EzRecommendationClient\Strategy\Storage;
 
 use EzSystems\EzRecommendationClient\Exception\UnsupportedGroupItemStrategy;
-use Ibexa\Contracts\Personalization\Criteria\CriteriaInterface;
-use Ibexa\Contracts\Personalization\Storage\DataSourceInterface;
-use Ibexa\Contracts\Personalization\Value\ItemGroupListInterface;
+use Ibexa\Contracts\PersonalizationClient\Criteria\CriteriaInterface;
+use Ibexa\Contracts\PersonalizationClient\Storage\DataSourceInterface;
+use Ibexa\Contracts\PersonalizationClient\Value\ItemGroupListInterface;
 use Traversable;
 
 final class GroupItemStrategyDispatcher implements GroupItemStrategyDispatcherInterface

--- a/src/lib/Strategy/Storage/GroupItemStrategyDispatcherInterface.php
+++ b/src/lib/Strategy/Storage/GroupItemStrategyDispatcherInterface.php
@@ -8,9 +8,9 @@ declare(strict_types=1);
 
 namespace EzSystems\EzRecommendationClient\Strategy\Storage;
 
-use Ibexa\Contracts\Personalization\Criteria\CriteriaInterface;
-use Ibexa\Contracts\Personalization\Storage\DataSourceInterface;
-use Ibexa\Contracts\Personalization\Value\ItemGroupListInterface;
+use Ibexa\Contracts\PersonalizationClient\Criteria\CriteriaInterface;
+use Ibexa\Contracts\PersonalizationClient\Storage\DataSourceInterface;
+use Ibexa\Contracts\PersonalizationClient\Value\ItemGroupListInterface;
 
 interface GroupItemStrategyDispatcherInterface
 {

--- a/src/lib/Strategy/Storage/GroupItemStrategyInterface.php
+++ b/src/lib/Strategy/Storage/GroupItemStrategyInterface.php
@@ -8,9 +8,9 @@ declare(strict_types=1);
 
 namespace EzSystems\EzRecommendationClient\Strategy\Storage;
 
-use Ibexa\Contracts\Personalization\Criteria\CriteriaInterface;
-use Ibexa\Contracts\Personalization\Storage\DataSourceInterface;
-use Ibexa\Contracts\Personalization\Value\ItemGroupListInterface;
+use Ibexa\Contracts\PersonalizationClient\Criteria\CriteriaInterface;
+use Ibexa\Contracts\PersonalizationClient\Storage\DataSourceInterface;
+use Ibexa\Contracts\PersonalizationClient\Value\ItemGroupListInterface;
 
 /**
  * @internal

--- a/src/lib/Strategy/Storage/SupportedGroupItemStrategy.php
+++ b/src/lib/Strategy/Storage/SupportedGroupItemStrategy.php
@@ -6,7 +6,7 @@
  */
 declare(strict_types=1);
 
-namespace Ibexa\Personalization\Strategy\Storage;
+namespace Ibexa\PersonalizationClient\Strategy\Storage;
 
 final class SupportedGroupItemStrategy
 {

--- a/src/lib/Value/Export/Parameters.php
+++ b/src/lib/Value/Export/Parameters.php
@@ -6,7 +6,7 @@
  */
 declare(strict_types=1);
 
-namespace Ibexa\Personalization\Value\Export;
+namespace Ibexa\PersonalizationClient\Value\Export;
 
 use EzSystems\EzRecommendationClient\Helper\ParamsConverterHelper;
 

--- a/src/lib/Value/Storage/Item.php
+++ b/src/lib/Value/Storage/Item.php
@@ -6,10 +6,10 @@
  */
 declare(strict_types=1);
 
-namespace Ibexa\Personalization\Value\Storage;
+namespace Ibexa\PersonalizationClient\Value\Storage;
 
-use Ibexa\Contracts\Personalization\Value\ItemInterface;
-use Ibexa\Contracts\Personalization\Value\ItemTypeInterface;
+use Ibexa\Contracts\PersonalizationClient\Value\ItemInterface;
+use Ibexa\Contracts\PersonalizationClient\Value\ItemTypeInterface;
 
 final class Item implements ItemInterface
 {

--- a/src/lib/Value/Storage/ItemGroup.php
+++ b/src/lib/Value/Storage/ItemGroup.php
@@ -6,10 +6,10 @@
  */
 declare(strict_types=1);
 
-namespace Ibexa\Personalization\Value\Storage;
+namespace Ibexa\PersonalizationClient\Value\Storage;
 
-use Ibexa\Contracts\Personalization\Value\ItemGroupInterface;
-use Ibexa\Contracts\Personalization\Value\ItemListInterface;
+use Ibexa\Contracts\PersonalizationClient\Value\ItemGroupInterface;
+use Ibexa\Contracts\PersonalizationClient\Value\ItemListInterface;
 
 final class ItemGroup implements ItemGroupInterface
 {

--- a/src/lib/Value/Storage/ItemGroupList.php
+++ b/src/lib/Value/Storage/ItemGroupList.php
@@ -6,23 +6,23 @@
  */
 declare(strict_types=1);
 
-namespace Ibexa\Personalization\Value\Storage;
+namespace Ibexa\PersonalizationClient\Value\Storage;
 
 use ArrayIterator;
-use Ibexa\Contracts\Personalization\Value\ItemGroupListInterface;
+use Ibexa\Contracts\PersonalizationClient\Value\ItemGroupListInterface;
 use IteratorAggregate;
 use Traversable;
 
 /**
- * @implements IteratorAggregate<\Ibexa\Contracts\Personalization\Value\ItemGroupInterface>
+ * @implements IteratorAggregate<\Ibexa\Contracts\PersonalizationClient\Value\ItemGroupInterface>
  */
 final class ItemGroupList implements IteratorAggregate, ItemGroupListInterface
 {
-    /** @var array<\Ibexa\Contracts\Personalization\Value\ItemGroupInterface> */
+    /** @var array<\Ibexa\Contracts\PersonalizationClient\Value\ItemGroupInterface> */
     private array $groups;
 
     /**
-     * @param array<\Ibexa\Contracts\Personalization\Value\ItemGroupInterface> $groups
+     * @param array<\Ibexa\Contracts\PersonalizationClient\Value\ItemGroupInterface> $groups
      */
     public function __construct(array $groups)
     {

--- a/src/lib/Value/Storage/ItemList.php
+++ b/src/lib/Value/Storage/ItemList.php
@@ -6,27 +6,27 @@
  */
 declare(strict_types=1);
 
-namespace Ibexa\Personalization\Value\Storage;
+namespace Ibexa\PersonalizationClient\Value\Storage;
 
 use ArrayIterator;
 use Closure;
 use eZ\Publish\API\Repository\Exceptions\OutOfBoundsException;
 use EzSystems\EzRecommendationClient\Exception\ItemNotFoundException;
-use Ibexa\Contracts\Personalization\Value\ItemInterface;
-use Ibexa\Contracts\Personalization\Value\ItemListInterface;
+use Ibexa\Contracts\PersonalizationClient\Value\ItemInterface;
+use Ibexa\Contracts\PersonalizationClient\Value\ItemListInterface;
 use IteratorAggregate;
 use Traversable;
 
 /**
- * @implements IteratorAggregate<\Ibexa\Contracts\Personalization\Value\ItemInterface>
+ * @implements IteratorAggregate<\Ibexa\Contracts\PersonalizationClient\Value\ItemInterface>
  */
 final class ItemList implements IteratorAggregate, ItemListInterface
 {
-    /** @var array<\Ibexa\Contracts\Personalization\Value\ItemInterface> */
+    /** @var array<\Ibexa\Contracts\PersonalizationClient\Value\ItemInterface> */
     private array $items;
 
     /**
-     * @param array<\Ibexa\Contracts\Personalization\Value\ItemInterface> $items
+     * @param array<\Ibexa\Contracts\PersonalizationClient\Value\ItemInterface> $items
      */
     public function __construct(array $items)
     {
@@ -91,7 +91,7 @@ final class ItemList implements IteratorAggregate, ItemListInterface
     }
 
     /**
-     * @param \Traversable<\Ibexa\Contracts\Personalization\Value\ItemInterface> $traversable
+     * @param \Traversable<\Ibexa\Contracts\PersonalizationClient\Value\ItemInterface> $traversable
      */
     public static function fromTraversable(Traversable $traversable): ItemListInterface
     {

--- a/src/lib/Value/Storage/ItemType.php
+++ b/src/lib/Value/Storage/ItemType.php
@@ -6,10 +6,10 @@
  */
 declare(strict_types=1);
 
-namespace Ibexa\Personalization\Value\Storage;
+namespace Ibexa\PersonalizationClient\Value\Storage;
 
 use eZ\Publish\API\Repository\Values\ContentType\ContentType;
-use Ibexa\Contracts\Personalization\Value\ItemTypeInterface;
+use Ibexa\Contracts\PersonalizationClient\Value\ItemTypeInterface;
 
 final class ItemType implements ItemTypeInterface
 {

--- a/tests/bundle/Command/AbstractCommandTestCase.php
+++ b/tests/bundle/Command/AbstractCommandTestCase.php
@@ -6,9 +6,9 @@
  */
 declare(strict_types=1);
 
-namespace Ibexa\Tests\Bundle\Personalization\Command;
+namespace Ibexa\Tests\Bundle\PersonalizationClient\Command;
 
-use Ibexa\Tests\Integration\Personalization\IbexaKernelTestCase;
+use Ibexa\Tests\Integration\PersonalizationClient\IbexaKernelTestCase;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Tester\CommandTester;

--- a/tests/bundle/Command/ExportCommandTest.php
+++ b/tests/bundle/Command/ExportCommandTest.php
@@ -6,7 +6,7 @@
  */
 declare(strict_types=1);
 
-namespace Ibexa\Tests\Bundle\Personalization\Command;
+namespace Ibexa\Tests\Bundle\PersonalizationClient\Command;
 
 use EzSystems\EzRecommendationClient\Exception\InvalidArgumentException;
 use EzSystems\EzRecommendationClient\Exception\MissingExportParameterException;

--- a/tests/integration/IbexaKernelTestCase.php
+++ b/tests/integration/IbexaKernelTestCase.php
@@ -6,7 +6,7 @@
  */
 declare(strict_types=1);
 
-namespace Ibexa\Tests\Integration\Personalization;
+namespace Ibexa\Tests\Integration\PersonalizationClient;
 
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 

--- a/tests/integration/IbexaTestKernel.php
+++ b/tests/integration/IbexaTestKernel.php
@@ -6,7 +6,7 @@
  */
 declare(strict_types=1);
 
-namespace Ibexa\Tests\Integration\Personalization;
+namespace Ibexa\Tests\Integration\PersonalizationClient;
 
 use Doctrine\Bundle\DoctrineBundle\DoctrineBundle;
 use eZ\Bundle\EzPublishCoreBundle\EzPublishCoreBundle;

--- a/tests/lib/Creator/DataSourceTestItemCreator.php
+++ b/tests/lib/Creator/DataSourceTestItemCreator.php
@@ -6,21 +6,21 @@
  */
 declare(strict_types=1);
 
-namespace Ibexa\Tests\Personalization\Creator;
+namespace Ibexa\Tests\PersonalizationClient\Creator;
 
 use ArrayIterator;
-use Ibexa\Contracts\Personalization\Criteria\CriteriaInterface;
-use Ibexa\Contracts\Personalization\Value\ItemGroupInterface;
-use Ibexa\Contracts\Personalization\Value\ItemGroupListInterface;
-use Ibexa\Contracts\Personalization\Value\ItemInterface;
-use Ibexa\Contracts\Personalization\Value\ItemListInterface;
-use Ibexa\Contracts\Personalization\Value\ItemTypeInterface;
-use Ibexa\Personalization\Criteria\Criteria;
-use Ibexa\Personalization\Value\Storage\Item;
-use Ibexa\Personalization\Value\Storage\ItemGroup;
-use Ibexa\Personalization\Value\Storage\ItemGroupList;
-use Ibexa\Personalization\Value\Storage\ItemList;
-use Ibexa\Personalization\Value\Storage\ItemType;
+use Ibexa\Contracts\PersonalizationClient\Criteria\CriteriaInterface;
+use Ibexa\Contracts\PersonalizationClient\Value\ItemGroupInterface;
+use Ibexa\Contracts\PersonalizationClient\Value\ItemGroupListInterface;
+use Ibexa\Contracts\PersonalizationClient\Value\ItemInterface;
+use Ibexa\Contracts\PersonalizationClient\Value\ItemListInterface;
+use Ibexa\Contracts\PersonalizationClient\Value\ItemTypeInterface;
+use Ibexa\PersonalizationClient\Criteria\Criteria;
+use Ibexa\PersonalizationClient\Value\Storage\Item;
+use Ibexa\PersonalizationClient\Value\Storage\ItemGroup;
+use Ibexa\PersonalizationClient\Value\Storage\ItemGroupList;
+use Ibexa\PersonalizationClient\Value\Storage\ItemList;
+use Ibexa\PersonalizationClient\Value\Storage\ItemType;
 use Traversable;
 
 final class DataSourceTestItemCreator
@@ -60,7 +60,7 @@ final class DataSourceTestItemCreator
      *  'limit': int,
      * }> $itemsConfig
      *
-     * @return Traversable<\Ibexa\Contracts\Personalization\Value\ItemInterface>
+     * @return Traversable<\Ibexa\Contracts\PersonalizationClient\Value\ItemInterface>
      */
     public function createTestItems(?iterable $itemsConfig = null): Traversable
     {
@@ -238,7 +238,7 @@ final class DataSourceTestItemCreator
     }
 
     /**
-     * @return array<\Ibexa\Contracts\Personalization\Value\ItemInterface>
+     * @return array<\Ibexa\Contracts\PersonalizationClient\Value\ItemInterface>
      */
     public function createTestItemsForEnglishArticles(): array
     {
@@ -263,7 +263,7 @@ final class DataSourceTestItemCreator
     }
 
     /**
-     * @return array<\Ibexa\Contracts\Personalization\Value\ItemInterface>
+     * @return array<\Ibexa\Contracts\PersonalizationClient\Value\ItemInterface>
      */
     public function createTestItemsForGermanArticles(): array
     {
@@ -288,7 +288,7 @@ final class DataSourceTestItemCreator
     }
 
     /**
-     * @return array<\Ibexa\Contracts\Personalization\Value\ItemInterface>
+     * @return array<\Ibexa\Contracts\PersonalizationClient\Value\ItemInterface>
      */
     public function createTestItemsForEnglishBlogPosts(): array
     {
@@ -321,7 +321,7 @@ final class DataSourceTestItemCreator
     }
 
     /**
-     * @return array<\Ibexa\Contracts\Personalization\Value\ItemInterface>
+     * @return array<\Ibexa\Contracts\PersonalizationClient\Value\ItemInterface>
      */
     public function createTestItemsForEnglishProducts(): array
     {
@@ -374,7 +374,7 @@ final class DataSourceTestItemCreator
      *  'limit': int,
      * }> $testItemsConfig
      *
-     * @return Traversable<\Ibexa\Contracts\Personalization\Value\ItemInterface>
+     * @return Traversable<\Ibexa\Contracts\PersonalizationClient\Value\ItemInterface>
      */
     private function createTestItemsForConfig(iterable $testItemsConfig): Traversable
     {
@@ -399,7 +399,7 @@ final class DataSourceTestItemCreator
      *  'limit': int,
      * }> $testItemsConfig
      *
-     * @return iterable<int, iterable<\Ibexa\Contracts\Personalization\Value\ItemInterface>>
+     * @return iterable<int, iterable<\Ibexa\Contracts\PersonalizationClient\Value\ItemInterface>>
      */
     private function createTestItemsForConcreteConfig(iterable $testItemsConfig): iterable
     {
@@ -421,7 +421,7 @@ final class DataSourceTestItemCreator
     /**
      * @param array<string> $languages
      *
-     * @return array<\Ibexa\Contracts\Personalization\Value\ItemInterface>
+     * @return array<\Ibexa\Contracts\PersonalizationClient\Value\ItemInterface>
      */
     private function createTestItemsForGivenLanguages(
         int $itemTypeId,

--- a/tests/lib/Export/Input/CommandInputResolverTest.php
+++ b/tests/lib/Export/Input/CommandInputResolverTest.php
@@ -6,10 +6,10 @@
  */
 declare(strict_types=1);
 
-namespace Ibexa\Test\Personalization\Export\Input;
+namespace Ibexa\Test\PersonalizationClient\Export\Input;
 
-use Ibexa\Personalization\Export\Input\CommandInputResolver;
-use Ibexa\Personalization\Export\Input\CommandInputResolverInterface;
+use Ibexa\PersonalizationClient\Export\Input\CommandInputResolver;
+use Ibexa\PersonalizationClient\Export\Input\CommandInputResolverInterface;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Input\InputArgument;

--- a/tests/lib/Factory/Export/ParametersFactoryTest.php
+++ b/tests/lib/Factory/Export/ParametersFactoryTest.php
@@ -6,7 +6,7 @@
  */
 declare(strict_types=1);
 
-namespace Ibexa\Test\Personalization\Factory\Export;
+namespace Ibexa\Test\PersonalizationClient\Factory\Export;
 
 use eZ\Publish\Core\MVC\ConfigResolverInterface;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess;
@@ -14,9 +14,9 @@ use eZ\Publish\Core\MVC\Symfony\SiteAccess\SiteAccessServiceInterface;
 use EzSystems\EzRecommendationClient\Config\CredentialsResolverInterface;
 use EzSystems\EzRecommendationClient\Exception\InvalidArgumentException;
 use EzSystems\EzRecommendationClient\Value\Config\EzRecommendationClientCredentials;
-use Ibexa\Personalization\Factory\Export\ParametersFactory;
-use Ibexa\Personalization\Factory\Export\ParametersFactoryInterface;
-use Ibexa\Personalization\Value\Export\Parameters;
+use Ibexa\PersonalizationClient\Factory\Export\ParametersFactory;
+use Ibexa\PersonalizationClient\Factory\Export\ParametersFactoryInterface;
+use Ibexa\PersonalizationClient\Value\Export\Parameters;
 use PHPUnit\Framework\TestCase;
 
 final class ParametersFactoryTest extends TestCase

--- a/tests/lib/Service/ExportNotificationServiceTest.php
+++ b/tests/lib/Service/ExportNotificationServiceTest.php
@@ -12,7 +12,7 @@ use EzSystems\EzRecommendationClient\API\Notifier;
 use EzSystems\EzRecommendationClient\Service\ExportNotificationService;
 use EzSystems\EzRecommendationClient\Value\ExportNotification;
 use GuzzleHttp\Psr7\Response;
-use Ibexa\Personalization\Value\Export\Parameters;
+use Ibexa\PersonalizationClient\Value\Export\Parameters;
 
 class ExportNotificationServiceTest extends NotificationServiceTest
 {
@@ -25,7 +25,7 @@ class ExportNotificationServiceTest extends NotificationServiceTest
     /** @var array<string> */
     private $notificationOptions;
 
-    /** @var \Ibexa\Personalization\Value\Export\Parameters */
+    /** @var \Ibexa\PersonalizationClient\Value\Export\Parameters */
     private $exportParameters;
 
     public function setUp(): void

--- a/tests/lib/Service/Storage/DataSourceServiceTest.php
+++ b/tests/lib/Service/Storage/DataSourceServiceTest.php
@@ -6,17 +6,17 @@
  */
 declare(strict_types=1);
 
-namespace Ibexa\Tests\Personalization\Service\Storage;
+namespace Ibexa\Tests\PersonalizationClient\Service\Storage;
 
 use EzSystems\EzRecommendationClient\Strategy\Storage\GroupItemStrategyDispatcherInterface;
-use Ibexa\Contracts\Personalization\Criteria\CriteriaInterface;
-use Ibexa\Contracts\Personalization\Storage\DataSourceInterface;
-use Ibexa\Contracts\Personalization\Value\ItemInterface;
-use Ibexa\Contracts\Personalization\Value\ItemListInterface;
-use Ibexa\Personalization\Service\Storage\DataSourceService;
-use Ibexa\Personalization\Strategy\Storage\SupportedGroupItemStrategy;
-use Ibexa\Tests\Personalization\Creator\DataSourceTestItemCreator;
-use Ibexa\Tests\Personalization\Storage\AbstractDataSourceTestCase;
+use Ibexa\Contracts\PersonalizationClient\Criteria\CriteriaInterface;
+use Ibexa\Contracts\PersonalizationClient\Storage\DataSourceInterface;
+use Ibexa\Contracts\PersonalizationClient\Value\ItemInterface;
+use Ibexa\Contracts\PersonalizationClient\Value\ItemListInterface;
+use Ibexa\PersonalizationClient\Service\Storage\DataSourceService;
+use Ibexa\PersonalizationClient\Strategy\Storage\SupportedGroupItemStrategy;
+use Ibexa\Tests\PersonalizationClient\Creator\DataSourceTestItemCreator;
+use Ibexa\Tests\PersonalizationClient\Storage\AbstractDataSourceTestCase;
 
 final class DataSourceServiceTest extends AbstractDataSourceTestCase
 {

--- a/tests/lib/Storage/AbstractContentDataSourceTestCase.php
+++ b/tests/lib/Storage/AbstractContentDataSourceTestCase.php
@@ -6,7 +6,7 @@
  */
 declare(strict_types=1);
 
-namespace Ibexa\Tests\Personalization\Storage;
+namespace Ibexa\Tests\PersonalizationClient\Storage;
 
 use eZ\Publish\API\Repository\ContentService;
 use eZ\Publish\API\Repository\SearchService;
@@ -22,11 +22,11 @@ use eZ\Publish\Core\QueryType\QueryType;
 use eZ\Publish\Core\Repository\Values\Content\Content;
 use eZ\Publish\Core\Repository\Values\Content\VersionInfo;
 use eZ\Publish\Core\Repository\Values\ContentType\ContentType;
-use Ibexa\Contracts\Personalization\Criteria\CriteriaInterface;
-use Ibexa\Contracts\Personalization\Storage\DataSourceInterface;
-use Ibexa\Personalization\Content\DataResolverInterface;
-use Ibexa\Personalization\Storage\ContentDataSource;
-use Ibexa\Tests\Personalization\Creator\DataSourceTestItemCreator;
+use Ibexa\Contracts\PersonalizationClient\Criteria\CriteriaInterface;
+use Ibexa\Contracts\PersonalizationClient\Storage\DataSourceInterface;
+use Ibexa\PersonalizationClient\Content\DataResolverInterface;
+use Ibexa\PersonalizationClient\Storage\ContentDataSource;
+use Ibexa\Tests\PersonalizationClient\Creator\DataSourceTestItemCreator;
 use Psr\Log\LoggerInterface;
 
 abstract class AbstractContentDataSourceTestCase extends AbstractDataSourceTestCase
@@ -49,7 +49,7 @@ abstract class AbstractContentDataSourceTestCase extends AbstractDataSourceTestC
     /** @var \eZ\Publish\Core\QueryType\QueryType|mixed|\PHPUnit\Framework\MockObject\MockObject */
     protected QueryType $queryType;
 
-    /** @var \Ibexa\Personalization\Content\DataResolverInterface|mixed|\PHPUnit\Framework\MockObject\MockObject */
+    /** @var \Ibexa\PersonalizationClient\Content\DataResolverInterface|mixed|\PHPUnit\Framework\MockObject\MockObject */
     protected DataResolverInterface $dataResolver;
 
     /** @var \Psr\Log\LoggerInterface|mixed|\PHPUnit\Framework\MockObject\MockObject */

--- a/tests/lib/Storage/AbstractDataSourceTestCase.php
+++ b/tests/lib/Storage/AbstractDataSourceTestCase.php
@@ -6,11 +6,11 @@
  */
 declare(strict_types=1);
 
-namespace Ibexa\Tests\Personalization\Storage;
+namespace Ibexa\Tests\PersonalizationClient\Storage;
 
-use Ibexa\Contracts\Personalization\Value\ItemListInterface;
-use Ibexa\Personalization\Value\Storage\ItemList;
-use Ibexa\Tests\Personalization\Creator\DataSourceTestItemCreator;
+use Ibexa\Contracts\PersonalizationClient\Value\ItemListInterface;
+use Ibexa\PersonalizationClient\Value\Storage\ItemList;
+use Ibexa\Tests\PersonalizationClient\Creator\DataSourceTestItemCreator;
 use PHPUnit\Framework\TestCase;
 
 abstract class AbstractDataSourceTestCase extends TestCase

--- a/tests/lib/Storage/AbstractItemTestCase.php
+++ b/tests/lib/Storage/AbstractItemTestCase.php
@@ -6,15 +6,15 @@
  */
 declare(strict_types=1);
 
-namespace Ibexa\Tests\Personalization\Storage;
+namespace Ibexa\Tests\PersonalizationClient\Storage;
 
 use EzSystems\EzRecommendationClient\Exception\ItemNotFoundException;
-use Ibexa\Contracts\Personalization\Criteria\CriteriaInterface;
-use Ibexa\Contracts\Personalization\Storage\DataSourceInterface;
-use Ibexa\Contracts\Personalization\Value\ItemInterface;
-use Ibexa\Contracts\Personalization\Value\ItemListInterface;
-use Ibexa\Personalization\Value\Storage\ItemList;
-use Ibexa\Tests\Personalization\Creator\DataSourceTestItemCreator;
+use Ibexa\Contracts\PersonalizationClient\Criteria\CriteriaInterface;
+use Ibexa\Contracts\PersonalizationClient\Storage\DataSourceInterface;
+use Ibexa\Contracts\PersonalizationClient\Value\ItemInterface;
+use Ibexa\Contracts\PersonalizationClient\Value\ItemListInterface;
+use Ibexa\PersonalizationClient\Value\Storage\ItemList;
+use Ibexa\Tests\PersonalizationClient\Creator\DataSourceTestItemCreator;
 
 abstract class AbstractItemTestCase extends AbstractDataSourceTestCase
 {
@@ -30,7 +30,7 @@ abstract class AbstractItemTestCase extends AbstractDataSourceTestCase
     }
 
     /**
-     * @param iterable<\Ibexa\Contracts\Personalization\Value\ItemInterface> $expectedItems
+     * @param iterable<\Ibexa\Contracts\PersonalizationClient\Value\ItemInterface> $expectedItems
      *
      * @dataProvider providerForTestFetchItems
      * @dataProvider providerForTestFetchItemListWithLimit
@@ -229,7 +229,7 @@ abstract class AbstractItemTestCase extends AbstractDataSourceTestCase
     }
 
     /**
-     * @param iterable<\Ibexa\Contracts\Personalization\Value\ItemInterface> $expectedItems
+     * @param iterable<\Ibexa\Contracts\PersonalizationClient\Value\ItemInterface> $expectedItems
      */
     protected function assertFetchItems(
         DataSourceInterface $source,

--- a/tests/lib/Storage/ContentDataSourceTest.php
+++ b/tests/lib/Storage/ContentDataSourceTest.php
@@ -6,18 +6,18 @@
  */
 declare(strict_types=1);
 
-namespace Ibexa\Tests\Personalization\Storage;
+namespace Ibexa\Tests\PersonalizationClient\Storage;
 
 use eZ\Publish\API\Repository\Values\Content\Content as ApiContent;
 use eZ\Publish\Core\Base\Exceptions\NotFoundException;
 use EzSystems\EzRecommendationClient\Exception\ItemNotFoundException;
-use Ibexa\Contracts\Personalization\Criteria\CriteriaInterface;
-use Ibexa\Contracts\Personalization\Value\ItemListInterface;
-use Ibexa\Personalization\Value\Storage\ItemList;
-use Ibexa\Tests\Personalization\Creator\DataSourceTestItemCreator;
+use Ibexa\Contracts\PersonalizationClient\Criteria\CriteriaInterface;
+use Ibexa\Contracts\PersonalizationClient\Value\ItemListInterface;
+use Ibexa\PersonalizationClient\Value\Storage\ItemList;
+use Ibexa\Tests\PersonalizationClient\Creator\DataSourceTestItemCreator;
 
 /**
- * @covers \Ibexa\Personalization\Storage\ContentDataSource
+ * @covers \Ibexa\PersonalizationClient\Storage\ContentDataSource
  */
 final class ContentDataSourceTest extends AbstractContentDataSourceTestCase
 {
@@ -144,7 +144,7 @@ final class ContentDataSourceTest extends AbstractContentDataSourceTestCase
 
     /**
      * @phpstan-return iterable<array{
-     *  \Ibexa\Contracts\Personalization\Criteria\CriteriaInterface,
+     *  \Ibexa\Contracts\PersonalizationClient\Criteria\CriteriaInterface,
      *  int,
      *  array<\eZ\Publish\API\Repository\Values\Content\Search\SearchHit>
      * }>
@@ -170,8 +170,8 @@ final class ContentDataSourceTest extends AbstractContentDataSourceTestCase
 
     /**
      * @phpstan-return iterable<array{
-     *  \Ibexa\Contracts\Personalization\Criteria\CriteriaInterface,
-     *  \Ibexa\Contracts\Personalization\Value\ItemListInterface,
+     *  \Ibexa\Contracts\PersonalizationClient\Criteria\CriteriaInterface,
+     *  \Ibexa\Contracts\PersonalizationClient\Value\ItemListInterface,
      *  array<\eZ\Publish\API\Repository\Values\Content\Search\SearchHit>,
      *  array<array{\eZ\Publish\API\Repository\Values\Content\Content, array<string>}>
      * }>

--- a/tests/lib/Storage/InMemoryDataSourceTest.php
+++ b/tests/lib/Storage/InMemoryDataSourceTest.php
@@ -6,11 +6,11 @@
  */
 declare(strict_types=1);
 
-namespace Ibexa\Tests\Personalization\Storage;
+namespace Ibexa\Tests\PersonalizationClient\Storage;
 
 use EzSystems\EzRecommendationClient\Storage\InMemoryDataSource;
-use Ibexa\Contracts\Personalization\Storage\DataSourceInterface;
-use Ibexa\Contracts\Personalization\Value\ItemListInterface;
+use Ibexa\Contracts\PersonalizationClient\Storage\DataSourceInterface;
+use Ibexa\Contracts\PersonalizationClient\Value\ItemListInterface;
 
 final class InMemoryDataSourceTest extends AbstractItemTestCase
 {

--- a/tests/lib/Strategy/Storage/GroupByItemTypeAndLanguageStrategyTest.php
+++ b/tests/lib/Strategy/Storage/GroupByItemTypeAndLanguageStrategyTest.php
@@ -6,19 +6,19 @@
  */
 declare(strict_types=1);
 
-namespace Ibexa\Tests\Personalization\Strategy\Storage;
+namespace Ibexa\Tests\PersonalizationClient\Strategy\Storage;
 
 use EzSystems\EzRecommendationClient\Strategy\Storage\GroupByItemTypeAndLanguageStrategy;
 use EzSystems\EzRecommendationClient\Strategy\Storage\GroupItemStrategyInterface;
-use Ibexa\Contracts\Personalization\Storage\DataSourceInterface;
-use Ibexa\Tests\Personalization\Creator\DataSourceTestItemCreator;
-use Ibexa\Tests\Personalization\Storage\AbstractDataSourceTestCase;
+use Ibexa\Contracts\PersonalizationClient\Storage\DataSourceInterface;
+use Ibexa\Tests\PersonalizationClient\Creator\DataSourceTestItemCreator;
+use Ibexa\Tests\PersonalizationClient\Storage\AbstractDataSourceTestCase;
 
 final class GroupByItemTypeAndLanguageStrategyTest extends AbstractDataSourceTestCase
 {
     private GroupItemStrategyInterface $strategy;
 
-    /** @var \Ibexa\Contracts\Personalization\Storage\DataSourceInterface|\PHPUnit\Framework\MockObject\MockObject */
+    /** @var \Ibexa\Contracts\PersonalizationClient\Storage\DataSourceInterface|\PHPUnit\Framework\MockObject\MockObject */
     private DataSourceInterface $dataSource;
 
     public function setUp(): void

--- a/tests/lib/Strategy/Storage/GroupItemStrategyDispatcherTest.php
+++ b/tests/lib/Strategy/Storage/GroupItemStrategyDispatcherTest.php
@@ -6,16 +6,16 @@
  */
 declare(strict_types=1);
 
-namespace Ibexa\Tests\Personalization\Strategy\Storage;
+namespace Ibexa\Tests\PersonalizationClient\Strategy\Storage;
 
 use EzSystems\EzRecommendationClient\Exception\UnsupportedGroupItemStrategy;
 use EzSystems\EzRecommendationClient\Strategy\Storage\GroupItemStrategyDispatcher;
 use EzSystems\EzRecommendationClient\Strategy\Storage\GroupItemStrategyDispatcherInterface;
 use EzSystems\EzRecommendationClient\Strategy\Storage\GroupItemStrategyInterface;
-use Ibexa\Contracts\Personalization\Storage\DataSourceInterface;
-use Ibexa\Personalization\Strategy\Storage\SupportedGroupItemStrategy;
-use Ibexa\Tests\Personalization\Creator\DataSourceTestItemCreator;
-use Ibexa\Tests\Personalization\Storage\AbstractDataSourceTestCase;
+use Ibexa\Contracts\PersonalizationClient\Storage\DataSourceInterface;
+use Ibexa\PersonalizationClient\Strategy\Storage\SupportedGroupItemStrategy;
+use Ibexa\Tests\PersonalizationClient\Creator\DataSourceTestItemCreator;
+use Ibexa\Tests\PersonalizationClient\Storage\AbstractDataSourceTestCase;
 
 final class GroupItemStrategyDispatcherTest extends AbstractDataSourceTestCase
 {
@@ -24,7 +24,7 @@ final class GroupItemStrategyDispatcherTest extends AbstractDataSourceTestCase
     /** @var \EzSystems\EzRecommendationClient\Strategy\Storage\GroupItemStrategyInterface|\PHPUnit\Framework\MockObject\MockObject */
     private GroupItemStrategyInterface $groupByItemTypeAndLanguages;
 
-    /** @var \Ibexa\Contracts\Personalization\Storage\DataSourceInterface|\PHPUnit\Framework\MockObject\MockObject */
+    /** @var \Ibexa\Contracts\PersonalizationClient\Storage\DataSourceInterface|\PHPUnit\Framework\MockObject\MockObject */
     private DataSourceInterface $dataSource;
 
     public function setUp(): void

--- a/tests/lib/Value/ItemListTest.php
+++ b/tests/lib/Value/ItemListTest.php
@@ -6,17 +6,17 @@
  */
 declare(strict_types=1);
 
-namespace Ibexa\Tests\Personalization\Value;
+namespace Ibexa\Tests\PersonalizationClient\Value;
 
-use Ibexa\Contracts\Personalization\Value\ItemInterface;
-use Ibexa\Contracts\Personalization\Value\ItemListInterface;
-use Ibexa\Personalization\Value\Storage\ItemList;
-use Ibexa\Tests\Personalization\Creator\DataSourceTestItemCreator;
-use Ibexa\Tests\Personalization\Storage\AbstractDataSourceTestCase;
+use Ibexa\Contracts\PersonalizationClient\Value\ItemInterface;
+use Ibexa\Contracts\PersonalizationClient\Value\ItemListInterface;
+use Ibexa\PersonalizationClient\Value\Storage\ItemList;
+use Ibexa\Tests\PersonalizationClient\Creator\DataSourceTestItemCreator;
+use Ibexa\Tests\PersonalizationClient\Storage\AbstractDataSourceTestCase;
 use OutOfBoundsException;
 
 /**
- * @covers \Ibexa\Personalization\Value\Storage\ItemList
+ * @covers \Ibexa\PersonalizationClient\Value\Storage\ItemList
  */
 final class ItemListTest extends AbstractDataSourceTestCase
 {
@@ -40,8 +40,8 @@ final class ItemListTest extends AbstractDataSourceTestCase
 
     /**
      * @phpstan-return iterable<array{
-     *  \Ibexa\Contracts\Personalization\Value\ItemListInterface,
-     *  \Ibexa\Contracts\Personalization\Value\ItemInterface
+     *  \Ibexa\Contracts\PersonalizationClient\Value\ItemListInterface,
+     *  \Ibexa\Contracts\PersonalizationClient\Value\ItemInterface
      * }>
      */
     public function provideDataForTestFirst(): iterable


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-1251](https://issues.ibexa.co/browse/IBX-1251)
| **Type**                                   | improvement
| **Target Ibexa DXP version** | `v4.0`
| **BC breaks**                          | no
| **Doc needed**                       | no

Due to namespace conflict during rebranding process all new classess should be moved to `PersonalizationClient` namespace

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/php-dev-team`).
