### PR TITLE
Fixed returned type UserHelper::getCurrentUser

### DIFF
--- a/src/lib/Helper/UserHelper.php
+++ b/src/lib/Helper/UserHelper.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace EzSystems\EzRecommendationClient\Helper;
 
+use eZ\Publish\Core\MVC\Symfony\Security\UserInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 
@@ -41,10 +42,10 @@ final class UserHelper
         $authenticationToken = $this->tokenStorage->getToken();
         $user = $authenticationToken->getUser();
 
-        if (\is_string($user)) {
+        if (is_string($user)) {
             return $user;
-        } elseif (method_exists($user, 'getAPIUser')) {
-            return $user->getAPIUser()->id;
+        } elseif ($user instanceof UserInterface) {
+            return (string) $user->getAPIUser()->id;
         }
 
         return (string) $authenticationToken->getUsername();


### PR DESCRIPTION
Changes provided in PR (https://github.com/ezsystems/ezrecommendation-client/pull/85/) cause the following errors 
```
[Application] Oct 27 09:01:39 |CRITICA| PHP    Uncaught Error: Return value of 
EzSystems\EzRecommendationClient\Helper\UserHelper::getCurrentUser() must be of the type string, int returned 
[Application] Oct 27 09:01:39 |CRITICA| REQUES Uncaught PHP Exception TypeError: "Return value of EzSystems\EzRecommendationClient\Helper\UserHelper::getCurrentUser() must be of the type string, int returned" at /tmp/untitled/vendor/ezsystems/ezrecommendation-client/src/lib/Helper/UserHelper.php line 47 
```

