### PR TITLE
IBX-1316: Added export Event and EventList

### DIFF
--- a/src/lib/Value/Export/Event.php
+++ b/src/lib/Value/Export/Event.php
@@ -1,0 +1,84 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\PersonalizationClient\Value\Export;
+
+final class Event
+{
+    private const ACTION_FULL_IMPORT = 'FULL';
+
+    private int $itemTypeId;
+
+    private string $itemTypeName;
+
+    private string $language;
+
+    /** @var array<string> */
+    private array $uriList;
+
+    private Credentials $credentials;
+
+    private string $format;
+
+    /**
+     * @param array<string> $uriList
+     */
+    public function __construct(
+        int $itemTypeId,
+        string $itemTypeName,
+        string $language,
+        array $uriList,
+        Credentials $credentials,
+        string $format = SupportedFormat::IBEXA
+    ) {
+        $this->itemTypeId = $itemTypeId;
+        $this->itemTypeName = $itemTypeName;
+        $this->language = $language;
+        $this->uriList = $uriList;
+        $this->credentials = $credentials;
+        $this->format = $format;
+    }
+
+    public function getItemTypeId(): int
+    {
+        return $this->itemTypeId;
+    }
+
+    public function getItemTypeName(): string
+    {
+        return $this->itemTypeName;
+    }
+
+    public function getLanguage(): string
+    {
+        return $this->language;
+    }
+
+    /**
+     * @return array<string>
+     */
+    public function getUriList(): array
+    {
+        return $this->uriList;
+    }
+
+    public function getCredentials(): Credentials
+    {
+        return $this->credentials;
+    }
+
+    public function getFormat(): string
+    {
+        return $this->format;
+    }
+
+    public function getAction(): string
+    {
+        return self::ACTION_FULL_IMPORT;
+    }
+}

--- a/src/lib/Value/Export/EventList.php
+++ b/src/lib/Value/Export/EventList.php
@@ -1,0 +1,80 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\PersonalizationClient\Value\Export;
+
+use ArrayAccess;
+use ArrayIterator;
+use BadMethodCallException;
+use eZ\Publish\API\Repository\Exceptions\OutOfBoundsException;
+use IteratorAggregate;
+use Traversable;
+use Webmozart\Assert\Assert;
+
+/**
+ * @implements IteratorAggregate<array-key, \Ibexa\PersonalizationClient\Value\Export\Event>
+ * @implements ArrayAccess<array-key, \Ibexa\PersonalizationClient\Value\Export\Event>
+ */
+final class EventList implements IteratorAggregate, ArrayAccess
+{
+    /** @var array<\Ibexa\PersonalizationClient\Value\Export\Event> */
+    private array $eventList;
+
+    /**
+     * @param array<\Ibexa\PersonalizationClient\Value\Export\Event> $eventList
+     */
+    public function __construct(array $eventList)
+    {
+        Assert::allIsInstanceOf($eventList, Event::class);
+
+        $this->eventList = $eventList;
+    }
+
+    public function getIterator(): Traversable
+    {
+        return new ArrayIterator($this->eventList);
+    }
+
+    public function offsetExists($offset): bool
+    {
+        return isset($this->eventList[$offset]);
+    }
+
+    public function offsetSet($offset, $value): void
+    {
+        throw new BadMethodCallException(
+            'Unsupported method'
+        );
+    }
+
+    public function offsetGet($offset): Event
+    {
+        if (false === $this->offsetExists($offset)) {
+            throw new OutOfBoundsException(
+                sprintf('The collection does not contain an element with index: %d', $offset)
+            );
+        }
+
+        return $this->eventList[$offset];
+    }
+
+    public function offsetUnset($offset): void
+    {
+        unset($this->eventList[$offset]);
+    }
+
+    public function countItemTypes(): int
+    {
+        $types = [];
+        foreach ($this->eventList as $event) {
+            $types[] = $event->getItemTypeName();
+        }
+
+        return count(array_unique($types));
+    }
+}

--- a/src/lib/Value/Export/SupportedFormat.php
+++ b/src/lib/Value/Export/SupportedFormat.php
@@ -1,0 +1,14 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\PersonalizationClient\Value\Export;
+
+final class SupportedFormat
+{
+    public const IBEXA = 'EZ';
+}


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-1316](https://issues.ibexa.co/browse/IBX-1316)
| **Type**                                   | feature
| **Target Ibexa DXP version** | `v4.0`
| **BC breaks**                          | no
| **Doc needed**                       | no

During the export process reco engine expects request body with following attributes:

```json
{
    "transaction": "transaction_id",
    "events": [{event1}, {event2}, {event3}...]
}
```
Single event has following format: 

```json
{
    "action": "action_name",
    "format": "format_type",
    "contentTypeId": content_type_id,
    "contentTypeName": "content_type_name",
    "lang": "language",
    "uri": ['path1', 'path2'],
    "credentials": {
        "login": "login",
        "password": "password"
    }
}
```

VO `Event` represents single event in request body and it is used in `Exporter`.

`EventList` is a collection of `Event` and additionally store information how many different item types will be exported. 

Both classess are required by refactored Exporter https://github.com/ezsystems/ezrecommendation-client/blob/1958a8d765aee59cb1435d5f04bcd20e701c84c5/src/lib/Exporter/Exporter.php

EventList is also required by `ExportNotificationService`.

Currently supported export format is only 'EZ' but to make it more extendable `SupportedFormat` class has been added. 

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/php-dev-team`).
