### PR TITLE
IBX-1448: Prevented sending login when customer_id is empty

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -356,11 +356,6 @@ parameters:
 			path: src/lib/Event/Listener/LoginListener.php
 
 		-
-			message: "#^Cannot access property \\$name on eZ\\\\Publish\\\\Core\\\\MVC\\\\Symfony\\\\SiteAccess|null\\.$#"
-			count: 1
-			path: src/lib/Event/Listener/LoginListener.php
-
-		-
 			message: "#^Method EzSystems\\\\EzRecommendationClient\\\\Event\\\\RecommendationResponseEvent\\:\\:getParameterBag\\(\\) should return Symfony\\\\Component\\\\HttpFoundation\\\\ParameterBag but returns Psr\\\\Http\\\\Message\\\\ResponseInterface\\|null\\.$#"
 			count: 1
 			path: src/lib/Event/RecommendationResponseEvent.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -356,12 +356,7 @@ parameters:
 			path: src/lib/Event/Listener/LoginListener.php
 
 		-
-			message: "#^Cannot call method debug\\(\\) on Psr\\\\Log\\\\LoggerInterface\\|null\\.$#"
-			count: 2
-			path: src/lib/Event/Listener/LoginListener.php
-
-		-
-			message: "#^Cannot call method error\\(\\) on Psr\\\\Log\\\\LoggerInterface\\|null\\.$#"
+			message: "#^Cannot access property \\$name on eZ\\\\Publish\\\\Core\\\\MVC\\\\Symfony\\\\SiteAccess|null\\.$#"
 			count: 1
 			path: src/lib/Event/Listener/LoginListener.php
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -376,6 +376,11 @@ parameters:
 			path: src/lib/Event/Listener/LoginListener.php
 
 		-
+			message: "#^Method EzSystems\\\\EzRecommendationClient\\\\Event\\\\Listener\\\\LoginListener\\:\\:getCustomerId\\(\\) never returns null so it can be removed from the return typehint\\.$#"
+			count: 1
+			path: src/lib/Event/Listener/LoginListener.php
+
+		-
 			message: "#^Method EzSystems\\\\EzRecommendationClient\\\\Event\\\\RecommendationResponseEvent\\:\\:__construct\\(\\) has parameter \\$parameterBag with no value type specified in iterable type Symfony\\\\Component\\\\HttpFoundation\\\\ParameterBag\\.$#"
 			count: 1
 			path: src/lib/Event/RecommendationResponseEvent.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -21,11 +21,6 @@ parameters:
 			path: src/bundle/Command/UserAttributesUpdateCommand.php
 
 		-
-			message: "#^Method EzSystems\\\\EzRecommendationClientBundle\\\\Controller\\\\ContentController\\:\\:getQuery\\(\\) has parameter \\$parameterBag with no value type specified in iterable type Symfony\\\\Component\\\\HttpFoundation\\\\ParameterBag\\.$#"
-			count: 1
-			path: src/bundle/Controller/ContentController.php
-
-		-
 			message: "#^PHPDoc tag @param has invalid value \\(\\\\Symfony\\\\Component\\\\HttpFoundation\\\\ParameterBag ParameterBag \\$parameterBag\\)\\: Unexpected token \"ParameterBag\", expected variable at offset 65$#"
 			count: 1
 			path: src/bundle/Controller/ContentController.php
@@ -49,11 +44,6 @@ parameters:
 			message: "#^Property EzSystems\\\\EzRecommendationClient\\\\SPI\\\\Content\\:\\:\\$lang \\(string\\|null\\) does not accept bool\\|float\\|int\\|string\\|null\\.$#"
 			count: 1
 			path: src/bundle/Controller/ContentController.php
-
-		-
-			message: "#^Method EzSystems\\\\EzRecommendationClientBundle\\\\Controller\\\\ContentTypeController\\:\\:getQuery\\(\\) has parameter \\$parameterBag with no value type specified in iterable type Symfony\\\\Component\\\\HttpFoundation\\\\ParameterBag\\.$#"
-			count: 1
-			path: src/bundle/Controller/ContentTypeController.php
 
 		-
 			message: "#^Method EzSystems\\\\EzRecommendationClientBundle\\\\Controller\\\\ContentTypeController\\:\\:prepareContentByContentTypeIds\\(\\) has parameter \\$contentTypeIds with no value type specified in iterable type array\\.$#"
@@ -366,6 +356,11 @@ parameters:
 			path: src/lib/Event/Listener/LoginListener.php
 
 		-
+			message: "#^Call to function is_string\\(\\) with Symfony\\\\Component\\\\Security\\\\Core\\\\User\\\\UserInterface\\|null will always evaluate to false\\.$#"
+			count: 1
+			path: src/lib/Event/Listener/LoginListener.php
+
+		-
 			message: "#^Cannot call method debug\\(\\) on Psr\\\\Log\\\\LoggerInterface\\|null\\.$#"
 			count: 2
 			path: src/lib/Event/Listener/LoginListener.php
@@ -381,14 +376,9 @@ parameters:
 			path: src/lib/Event/Listener/LoginListener.php
 
 		-
-			message: "#^Method EzSystems\\\\EzRecommendationClient\\\\Event\\\\RecommendationResponseEvent\\:\\:__construct\\(\\) has parameter \\$parameterBag with no value type specified in iterable type Symfony\\\\Component\\\\HttpFoundation\\\\ParameterBag\\.$#"
+			message: "#^Parameter \\#1 \\$object of function method_exists expects object\\|string, Symfony\\\\Component\\\\Security\\\\Core\\\\User\\\\UserInterface\\|null given\\.$#"
 			count: 1
-			path: src/lib/Event/RecommendationResponseEvent.php
-
-		-
-			message: "#^Method EzSystems\\\\EzRecommendationClient\\\\Event\\\\RecommendationResponseEvent\\:\\:getParameterBag\\(\\) return type has no value type specified in iterable type Symfony\\\\Component\\\\HttpFoundation\\\\ParameterBag\\.$#"
-			count: 1
-			path: src/lib/Event/RecommendationResponseEvent.php
+			path: src/lib/Event/Listener/LoginListener.php
 
 		-
 			message: "#^Method EzSystems\\\\EzRecommendationClient\\\\Event\\\\RecommendationResponseEvent\\:\\:getParameterBag\\(\\) should return Symfony\\\\Component\\\\HttpFoundation\\\\ParameterBag but returns Psr\\\\Http\\\\Message\\\\ResponseInterface\\|null\\.$#"
@@ -427,11 +417,6 @@ parameters:
 
 		-
 			message: "#^Method EzSystems\\\\EzRecommendationClient\\\\Event\\\\Subscriber\\\\RecommendationEventSubscriber\\:\\:extractRecommendationItems\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/lib/Event/Subscriber/RecommendationEventSubscriber.php
-
-		-
-			message: "#^Method EzSystems\\\\EzRecommendationClient\\\\Event\\\\Subscriber\\\\RecommendationEventSubscriber\\:\\:getRecommendationRequest\\(\\) has parameter \\$parameterBag with no value type specified in iterable type Symfony\\\\Component\\\\HttpFoundation\\\\ParameterBag\\.$#"
 			count: 1
 			path: src/lib/Event/Subscriber/RecommendationEventSubscriber.php
 
@@ -826,11 +811,6 @@ parameters:
 			path: src/lib/Helper/ExportProcessRunnerHelper.php
 
 		-
-			message: "#^Method EzSystems\\\\EzRecommendationClient\\\\Helper\\\\ExportProcessRunnerHelper\\:\\:run\\(\\) return type has no value type specified in iterable type Symfony\\\\Component\\\\Process\\\\Process\\.$#"
-			count: 1
-			path: src/lib/Helper/ExportProcessRunnerHelper.php
-
-		-
 			message: "#^Property EzSystems\\\\EzRecommendationClient\\\\Helper\\\\ExportProcessRunnerHelper\\:\\:\\$phpPath \\(string\\) does not accept string\\|false\\.$#"
 			count: 1
 			path: src/lib/Helper/ExportProcessRunnerHelper.php
@@ -911,6 +891,11 @@ parameters:
 			path: src/lib/Helper/SiteAccessHelper.php
 
 		-
+			message: "#^Call to function is_string\\(\\) with Symfony\\\\Component\\\\Security\\\\Core\\\\User\\\\UserInterface\\|null will always evaluate to false\\.$#"
+			count: 1
+			path: src/lib/Helper/UserHelper.php
+
+		-
 			message: "#^Cannot call method getUser\\(\\) on Symfony\\\\Component\\\\Security\\\\Core\\\\Authentication\\\\Token\\\\TokenInterface\\|null\\.$#"
 			count: 1
 			path: src/lib/Helper/UserHelper.php
@@ -919,51 +904,6 @@ parameters:
 			message: "#^Cannot call method getUsername\\(\\) on Symfony\\\\Component\\\\Security\\\\Core\\\\Authentication\\\\Token\\\\TokenInterface\\|null\\.$#"
 			count: 1
 			path: src/lib/Helper/UserHelper.php
-
-		-
-			message: "#^Method EzSystems\\\\EzRecommendationClient\\\\Mapper\\\\ExportRequestMapper\\:\\:getCustomerId\\(\\) has parameter \\$parameterBag with no value type specified in iterable type Symfony\\\\Component\\\\HttpFoundation\\\\ParameterBag\\.$#"
-			count: 1
-			path: src/lib/Mapper/ExportRequestMapper.php
-
-		-
-			message: "#^Method EzSystems\\\\EzRecommendationClient\\\\Mapper\\\\ExportRequestMapper\\:\\:getFields\\(\\) has parameter \\$parameterBag with no value type specified in iterable type Symfony\\\\Component\\\\HttpFoundation\\\\ParameterBag\\.$#"
-			count: 1
-			path: src/lib/Mapper/ExportRequestMapper.php
-
-		-
-			message: "#^Method EzSystems\\\\EzRecommendationClient\\\\Mapper\\\\ExportRequestMapper\\:\\:getImage\\(\\) has parameter \\$parameterBag with no value type specified in iterable type Symfony\\\\Component\\\\HttpFoundation\\\\ParameterBag\\.$#"
-			count: 1
-			path: src/lib/Mapper/ExportRequestMapper.php
-
-		-
-			message: "#^Method EzSystems\\\\EzRecommendationClient\\\\Mapper\\\\ExportRequestMapper\\:\\:getLang\\(\\) has parameter \\$parameterBag with no value type specified in iterable type Symfony\\\\Component\\\\HttpFoundation\\\\ParameterBag\\.$#"
-			count: 1
-			path: src/lib/Mapper/ExportRequestMapper.php
-
-		-
-			message: "#^Method EzSystems\\\\EzRecommendationClient\\\\Mapper\\\\ExportRequestMapper\\:\\:getLicenseKey\\(\\) has parameter \\$parameterBag with no value type specified in iterable type Symfony\\\\Component\\\\HttpFoundation\\\\ParameterBag\\.$#"
-			count: 1
-			path: src/lib/Mapper/ExportRequestMapper.php
-
-		-
-			message: "#^Method EzSystems\\\\EzRecommendationClient\\\\Mapper\\\\ExportRequestMapper\\:\\:getPath\\(\\) has parameter \\$parameterBag with no value type specified in iterable type Symfony\\\\Component\\\\HttpFoundation\\\\ParameterBag\\.$#"
-			count: 1
-			path: src/lib/Mapper/ExportRequestMapper.php
-
-		-
-			message: "#^Method EzSystems\\\\EzRecommendationClient\\\\Mapper\\\\ExportRequestMapper\\:\\:getSiteAccess\\(\\) has parameter \\$parameterBag with no value type specified in iterable type Symfony\\\\Component\\\\HttpFoundation\\\\ParameterBag\\.$#"
-			count: 1
-			path: src/lib/Mapper/ExportRequestMapper.php
-
-		-
-			message: "#^Method EzSystems\\\\EzRecommendationClient\\\\Mapper\\\\ExportRequestMapper\\:\\:getVisibility\\(\\) has parameter \\$parameterBag with no value type specified in iterable type Symfony\\\\Component\\\\HttpFoundation\\\\ParameterBag\\.$#"
-			count: 1
-			path: src/lib/Mapper/ExportRequestMapper.php
-
-		-
-			message: "#^Method EzSystems\\\\EzRecommendationClient\\\\Mapper\\\\ExportRequestMapper\\:\\:getWebHook\\(\\) has parameter \\$parameterBag with no value type specified in iterable type Symfony\\\\Component\\\\HttpFoundation\\\\ParameterBag\\.$#"
-			count: 1
-			path: src/lib/Mapper/ExportRequestMapper.php
 
 		-
 			message: "#^Property EzSystems\\\\EzRecommendationClient\\\\SPI\\\\Content\\:\\:\\$fields \\(array\\<string\\>\\) does not accept string\\|null\\.$#"

--- a/src/bundle/Resources/config/services/events.yaml
+++ b/src/bundle/Resources/config/services/events.yaml
@@ -8,6 +8,8 @@ services:
         resource: '../../../../src/lib/Event/*'
 
     EzSystems\EzRecommendationClient\Event\Listener\LoginListener:
+        arguments:
+            $siteAccessService: '@ezpublish.siteaccess_service'
         tags:
             - { name: kernel.event_listener, event: security.interactive_login, priority: 255 }
             - { name: monolog.logger, channel: ezrecommendation }

--- a/src/lib/Event/Listener/LoginListener.php
+++ b/src/lib/Event/Listener/LoginListener.php
@@ -8,7 +8,6 @@ declare(strict_types=1);
 
 namespace EzSystems\EzRecommendationClient\Event\Listener;
 
-use eZ\Publish\API\Repository\UserService as UserServiceInterface;
 use eZ\Publish\Core\MVC\ConfigResolverInterface;
 use EzSystems\EzRecommendationClient\Client\EzRecommendationClientInterface;
 use EzSystems\EzRecommendationClient\Value\Parameters;
@@ -34,9 +33,6 @@ final class LoginListener
     /** @var \EzSystems\EzRecommendationClient\Client\EzRecommendationClientInterface */
     private $client;
 
-    /** @var \eZ\Publish\API\Repository\UserService */
-    private $userService;
-
     /** @var \eZ\Publish\Core\MVC\ConfigResolverInterface */
     private $configResolver;
 
@@ -50,14 +46,12 @@ final class LoginListener
         AuthorizationCheckerInterface $authorizationChecker,
         SessionInterface $session,
         EzRecommendationClientInterface $client,
-        UserServiceInterface $userService,
         ConfigResolverInterface $configResolver,
         LoggerInterface $logger
     ) {
         $this->authorizationChecker = $authorizationChecker;
         $this->session = $session;
         $this->client = $client;
-        $this->userService = $userService;
         $this->configResolver = $configResolver;
         $this->logger = $logger;
     }
@@ -74,12 +68,7 @@ final class LoginListener
             return;
         }
 
-        $customerId = $this->configResolver->getParameter(
-            'authentication.customer_id',
-            Parameters::NAMESPACE
-        );
-
-        if (empty($customerId)) {
+        if (empty($this->getCustomerId())) {
             return;
         }
 
@@ -108,15 +97,20 @@ final class LoginListener
         }
     }
 
+    private function getCustomerId(): ?string
+    {
+        return (string) $this->configResolver->getParameter(
+            'authentication.customer_id',
+            Parameters::NAMESPACE
+        );
+    }
+
     /**
      * Returns notification API end-point.
      */
     private function getNotificationEndpoint(): string
     {
-        $customerId = $this->configResolver->getParameter(
-            'authentication.customer_id',
-            Parameters::NAMESPACE
-        );
+        $customerId = $this->getCustomerId();
         $trackingEndPoint = $this->configResolver->getParameter(
             Parameters::API_SCOPE . '.event_tracking.endpoint',
             Parameters::NAMESPACE

--- a/src/lib/Event/Listener/LoginListener.php
+++ b/src/lib/Event/Listener/LoginListener.php
@@ -81,22 +81,23 @@ final class LoginListener
         $siteAccessName = $currentSiteAccess->name;
         $endpoint = $this->getEndpoint($siteAccessName);
         $customerId = $this->getCustomerId($siteAccessName);
+        $sessionKey = RecommendationSession::RECOMMENDATION_SESSION_KEY;
 
         if (!isset($customerId, $endpoint)) {
             return;
         }
 
-        if (!$event->getRequest()->cookies->has(RecommendationSession::RECOMMENDATION_SESSION_KEY)) {
+        if (!$event->getRequest()->cookies->has($sessionKey)) {
             if (!$this->session->isStarted()) {
                 $this->session->start();
             }
-            $event->getRequest()->cookies->set(RecommendationSession::RECOMMENDATION_SESSION_KEY, $this->session->getId());
+            $event->getRequest()->cookies->set($sessionKey, $this->session->getId());
         }
 
         $notificationUri = $this->getNotificationUri(
             $endpoint,
             $customerId,
-            (string) $event->getRequest()->cookies->get(RecommendationSession::RECOMMENDATION_SESSION_KEY),
+            (string) $event->getRequest()->cookies->get($sessionKey),
             $this->getUser($event->getAuthenticationToken())
         );
 

--- a/src/lib/Event/Listener/LoginListener.php
+++ b/src/lib/Event/Listener/LoginListener.php
@@ -131,7 +131,7 @@ final class LoginListener
             $siteAccessName
         );
 
-        return $customerId === 0 ? null : $customerId;
+        return $customerId ?: null;
     }
 
     private function getEndpoint(string $siteAccessName): ?string

--- a/src/lib/Event/Listener/LoginListener.php
+++ b/src/lib/Event/Listener/LoginListener.php
@@ -72,7 +72,13 @@ final class LoginListener
             return;
         }
 
-        $siteAccessName = $this->siteAccessService->getCurrent()->name;
+        $currentSiteAccess = $this->siteAccessService->getCurrent();
+
+        if (empty($currentSiteAccess)) {
+            return;
+        }
+
+        $siteAccessName = $currentSiteAccess->name;
         $endpoint = $this->getEndpoint($siteAccessName);
         $customerId = $this->getCustomerId($siteAccessName);
 

--- a/src/lib/Event/Listener/LoginListener.php
+++ b/src/lib/Event/Listener/LoginListener.php
@@ -74,6 +74,15 @@ final class LoginListener
             return;
         }
 
+        $customerId = $this->configResolver->getParameter(
+            'authentication.customer_id',
+            Parameters::NAMESPACE
+        );
+
+        if (empty($customerId)) {
+            return;
+        }
+
         if (!$event->getRequest()->cookies->has(RecommendationSession::RECOMMENDATION_SESSION_KEY)) {
             if (!$this->session->isStarted()) {
                 $this->session->start();

--- a/src/lib/Event/Listener/LoginListener.php
+++ b/src/lib/Event/Listener/LoginListener.php
@@ -125,11 +125,13 @@ final class LoginListener
             return null;
         }
 
-        return (int) $this->configResolver->getParameter(
+        $customerId = (int)$this->configResolver->getParameter(
             $parameterNameCustomerId,
             Parameters::NAMESPACE,
             $siteAccessName
         );
+
+        return $customerId === 0 ? null : $customerId;
     }
 
     private function getEndpoint(string $siteAccessName): ?string

--- a/src/lib/Event/Listener/LoginListener.php
+++ b/src/lib/Event/Listener/LoginListener.php
@@ -74,7 +74,7 @@ final class LoginListener
 
         $currentSiteAccess = $this->siteAccessService->getCurrent();
 
-        if (empty($currentSiteAccess)) {
+        if ($currentSiteAccess === null) {
             return;
         }
 

--- a/src/lib/Event/Listener/LoginListener.php
+++ b/src/lib/Event/Listener/LoginListener.php
@@ -98,7 +98,7 @@ final class LoginListener
         }
     }
 
-    private function getCustomerId(): ?string
+    private function getCustomerId(): string
     {
         return (string) $this->configResolver->getParameter(
             'authentication.customer_id',


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-1448](https://issues.ibexa.co/browse/IBX-1448)
| **Type**                                   | bug
| **Target Ibexa DXP version** | `v3.3` 
| **BC breaks**                          | no
| **Doc needed**                       | no

<!-- Replace this comment with Pull Request description -->

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/php-dev-team`).
