### PR TITLE
IBX-1972: Fixed get parent location path string

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -786,11 +786,6 @@ parameters:
 			path: src/lib/Helper/ImageHelper.php
 
 		-
-			message: "#^Parameter \\#1 \\$locationId of method eZ\\\\Publish\\\\API\\\\Repository\\\\LocationService\\:\\:loadLocation\\(\\) expects int, int\\|null given\\.$#"
-			count: 1
-			path: src/lib/Helper/LocationHelper.php
-
-		-
 			message: "#^Method EzSystems\\\\EzRecommendationClient\\\\Helper\\\\ParamsConverterHelper\\:\\:getArrayFromString\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/lib/Helper/ParamsConverterHelper.php


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-1972](https://issues.ibexa.co/browse/IBX-1972)
| **Type**                                   | improvement
| **Target Ibexa DXP version** | `v3.3.13`
| **BC breaks**                          | no
| **Doc needed**                       | no

This PR adds fix for providing parent location path string which is used in recommendation request. When there is no possible to get current location or parent location id null should be returned. This could occurs during create draft of landing page.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/php-dev-team`).
