### PR TITLE
IBX-2324: Added configuration parameter and RepositoryConfigResolver to allow use content remote id

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,7 @@
     },
     "autoload": {
         "psr-4": {
+            "Ibexa\\Personalization\\": "src/lib/",
             "EzSystems\\EzRecommendationClientBundle\\": "src/bundle/",
             "EzSystems\\EzRecommendationClient\\": "src/lib/"
         }

--- a/src/bundle/DependencyInjection/Configuration.php
+++ b/src/bundle/DependencyInjection/Configuration.php
@@ -192,7 +192,17 @@ class Configuration extends SiteAccessConfiguration
                     ->end()
                 ->end()
             ->end()
-        ;
+            ->arrayNode('repository')
+                ->children()
+                    ->arrayNode('content')
+                        ->children()
+                            ->booleanNode('use_remote_id')
+                                ->info('Use remote id instead of numeric content id to process recommendations')
+                            ->end()
+                        ->end()
+                    ->end()
+                ->end()
+            ->end();
 
         return $treeBuilder;
     }

--- a/src/bundle/DependencyInjection/ConfigurationMapper.php
+++ b/src/bundle/DependencyInjection/ConfigurationMapper.php
@@ -68,7 +68,11 @@ class ConfigurationMapper implements HookableConfigurationMapperInterface
         }
 
         if (isset($scopeSettings['repository']['content']['use_remote_id'])) {
-            $contextualizer->setContextualParameter('repository.content.use_remote_id', $currentScope, $scopeSettings['repository']['content']['use_remote_id']);
+            $contextualizer->setContextualParameter(
+                'repository.content.use_remote_id',
+                $currentScope,
+                $scopeSettings['repository']['content']['use_remote_id']
+            );
         }
 
         if (isset($scopeSettings['api'])) {

--- a/src/bundle/DependencyInjection/ConfigurationMapper.php
+++ b/src/bundle/DependencyInjection/ConfigurationMapper.php
@@ -67,6 +67,10 @@ class ConfigurationMapper implements HookableConfigurationMapperInterface
             $contextualizer->setContextualParameter('user_api.default_source', $currentScope, $scopeSettings['user_api']['default_source']);
         }
 
+        if (isset($scopeSettings['repository']['content']['use_remote_id'])) {
+            $contextualizer->setContextualParameter('repository.content.use_remote_id', $currentScope, $scopeSettings['repository']['content']['use_remote_id']);
+        }
+
         if (isset($scopeSettings['api'])) {
             $this->setApiSettings($contextualizer, $currentScope, $scopeSettings['api']);
         }

--- a/src/bundle/Resources/config/default_settings.yaml
+++ b/src/bundle/Resources/config/default_settings.yaml
@@ -34,3 +34,5 @@ parameters:
 
     ezrecommendation.default.field.relations: []
     ezrecommendation.default.field.identifiers: []
+
+    ezrecommendation.default.repository.content.use_remote_id: false

--- a/src/bundle/Resources/config/services.yaml
+++ b/src/bundle/Resources/config/services.yaml
@@ -3,9 +3,9 @@ imports:
     - { resource: services/authenticators.yaml }
     - { resource: services/client.yaml }
     - { resource: services/commands.yaml }
+    - { resource: services/config.yaml }
     - { resource: services/controllers.yaml }
     - { resource: services/converters.yaml }
-    - { resource: services/credentials_checker.yaml }
     - { resource: services/events.yaml }
     - { resource: services/exporter.yaml }
     - { resource: services/factory.yaml }

--- a/src/bundle/Resources/config/services/config.yaml
+++ b/src/bundle/Resources/config/services/config.yaml
@@ -1,0 +1,16 @@
+services:
+    _defaults:
+        autowire: true
+        autoconfigure: true
+        public: false
+
+    EzSystems\EzRecommendationClient\Config\CredentialsResolver: ~
+
+    EzSystems\EzRecommendationClient\Config\EzRecommendationClientCredentialsResolver: ~
+
+    EzSystems\EzRecommendationClient\Config\ExportCredentialsResolver: ~
+
+    Ibexa\Personalization\Config\Repository\RepositoryConfigResolver: ~
+
+    Ibexa\Personalization\Config\Repository\RepositoryConfigResolverInterface:
+        '@Ibexa\Personalization\Config\Repository\RepositoryConfigResolver'

--- a/src/bundle/Resources/config/services/credentials_checker.yaml
+++ b/src/bundle/Resources/config/services/credentials_checker.yaml
@@ -1,8 +1,0 @@
-services:
-    _defaults:
-        autowire: true
-        autoconfigure: true
-        public: false
-
-    EzSystems\EzRecommendationClient\Config\:
-        resource: '../../../../src/lib/Config/*'

--- a/src/lib/Config/Repository/RepositoryConfigResolver.php
+++ b/src/lib/Config/Repository/RepositoryConfigResolver.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Personalization\Config\Repository;
+
+use eZ\Publish\Core\MVC\ConfigResolverInterface;
+use EzSystems\EzRecommendationClient\Value\Parameters;
+
+/**
+ * @internal
+ */
+final class RepositoryConfigResolver implements RepositoryConfigResolverInterface
+{
+    private const USE_CONTENT_REMOTE_ID_PARAMETER = 'repository.content.use_remote_id';
+
+    /** @var \eZ\Publish\Core\MVC\ConfigResolverInterface */
+    private $configResolver;
+
+    public function __construct(ConfigResolverInterface $configResolver)
+    {
+        $this->configResolver = $configResolver;
+    }
+
+    public function useRemoteId(): bool
+    {
+        if (
+            !$this->configResolver->hasParameter(
+                self::USE_CONTENT_REMOTE_ID_PARAMETER,
+                Parameters::NAMESPACE
+            )
+        ) {
+            return false;
+        }
+
+        return $this->configResolver->getParameter(
+            self::USE_CONTENT_REMOTE_ID_PARAMETER,
+            Parameters::NAMESPACE
+        );
+    }
+}

--- a/src/lib/Config/Repository/RepositoryConfigResolverInterface.php
+++ b/src/lib/Config/Repository/RepositoryConfigResolverInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Personalization\Config\Repository;
+
+/**
+ * @internal
+ */
+interface RepositoryConfigResolverInterface
+{
+    public function useRemoteId(): bool;
+}

--- a/tests/lib/Config/Repository/RepositoryConfigResolverTest.php
+++ b/tests/lib/Config/Repository/RepositoryConfigResolverTest.php
@@ -1,0 +1,73 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\Personalization\Config\Repository;
+
+use eZ\Publish\Core\MVC\ConfigResolverInterface;
+use Ibexa\Personalization\Config\Repository\RepositoryConfigResolver;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Ibexa\Personalization\Config\Repository\RepositoryConfigResolver
+ */
+final class RepositoryConfigResolverTest extends TestCase
+{
+    /** @var \eZ\Publish\Core\MVC\ConfigResolverInterface|\PHPUnit\Framework\MockObject\MockObject */
+    private $configResolver;
+
+    /** @var \Ibexa\Personalization\Config\Repository\RepositoryConfigResolverInterface */
+    private $repositoryConfigResolver;
+
+    protected function setUp(): void
+    {
+        $this->configResolver = $this->createMock(ConfigResolverInterface::class);
+        $this->repositoryConfigResolver = new RepositoryConfigResolver($this->configResolver);
+    }
+
+    public function testUseRemoteId(): void
+    {
+        $this->mockConfigResolverHasParameter(true);
+        $this->mockConfigResolverGetParameter(true);
+
+        self::assertTrue($this->repositoryConfigResolver->useRemoteId());
+    }
+
+    public function testDoNotUseRemoteIdWhenParameterIsNotDefined(): void
+    {
+        $this->mockConfigResolverHasParameter(false);
+        $this->mockConfigResolverGetParameter(false);
+
+        self::assertFalse($this->repositoryConfigResolver->useRemoteId());
+    }
+
+    public function testDoNotUseRemoteIdWhenParameterValueIsFalse(): void
+    {
+        $this->mockConfigResolverHasParameter(true);
+        $this->mockConfigResolverGetParameter(false);
+
+        self::assertFalse($this->repositoryConfigResolver->useRemoteId());
+    }
+
+    private function mockConfigResolverHasParameter(bool $hasParameter): void
+    {
+        $this->configResolver
+            ->expects(self::once())
+            ->method('hasParameter')
+            ->with('repository.content.use_remote_id', 'ezrecommendation')
+            ->willReturn($hasParameter);
+    }
+
+    private function mockConfigResolverGetParameter(bool $useRemoteId): void
+    {
+        $this->configResolver
+            ->expects(self::once())
+            ->method('getParameter')
+            ->with('repository.content.use_remote_id', 'ezrecommendation')
+            ->willReturn($useRemoteId);
+    }
+}


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-2324](https://issues.ibexa.co/browse/IBX-2324)
| **Type**                                   | feature
| **Target Ibexa DXP version** | `v3.3.15`, `v4.0.2`
| **BC breaks**                          | no
| **Doc needed**                       | yes

This PR provides `repository.content.use_remote_id` parameter under `ezrecommendation` namespace which allow to use alphanumeric content `remoteId` instead of numeric `id`. By default this options is set to false because support for remoteId for given customer should be enabled first in recommendation engine. 

There is also added `RepositoryConfigResolver` to provides repository configuration settings. 

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/php-dev-team`).
