### PR TITLE
IBX-2367: Dropped sendDeliveryFeedback from RecommendationController

### DIFF
--- a/src/bundle/Controller/RecommendationController.php
+++ b/src/bundle/Controller/RecommendationController.php
@@ -10,8 +10,6 @@ namespace EzSystems\EzRecommendationClientBundle\Controller;
 
 use EzSystems\EzRecommendationClient\Config\CredentialsResolverInterface;
 use EzSystems\EzRecommendationClient\Event\RecommendationResponseEvent;
-use EzSystems\EzRecommendationClient\Request\BasicRecommendationRequest;
-use EzSystems\EzRecommendationClient\Service\RecommendationServiceInterface;
 use Ramsey\Uuid\Uuid;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\Request;
@@ -25,26 +23,18 @@ class RecommendationController
     /** @var \Symfony\Component\EventDispatcher\EventDispatcherInterface */
     private $eventDispatcher;
 
-    /** @var \EzSystems\EzRecommendationClient\Service\RecommendationServiceInterface */
-    private $recommendationService;
-
     /** @var \EzSystems\EzRecommendationClient\Config\CredentialsResolverInterface */
     private $credentialsResolver;
 
     /** @var \Twig\Environment */
     private $twig;
 
-    /** @var bool */
-    private $sendDeliveryFeedback = true;
-
     public function __construct(
         EventDispatcherInterface $eventDispatcher,
-        RecommendationServiceInterface $recommendationService,
         CredentialsResolverInterface $credentialsResolver,
         Environment $twig
     ) {
         $this->eventDispatcher = $eventDispatcher;
-        $this->recommendationService = $recommendationService;
         $this->credentialsResolver = $credentialsResolver;
         $this->twig = $twig;
     }
@@ -70,21 +60,12 @@ class RecommendationController
         $response = new Response();
         $response->setPrivate();
 
-        if ($this->sendDeliveryFeedback) {
-            $this->recommendationService->sendDeliveryFeedback($request->get(BasicRecommendationRequest::OUTPUT_TYPE_ID_KEY));
-        }
-
         return $response->setContent(
             $this->twig()->render($template, [
             'recommendations' => $event->getRecommendationItems(),
             'templateId' => Uuid::uuid4()->toString(),
             ])
         );
-    }
-
-    public function sendDeliveryFeedback(bool $value): void
-    {
-        $this->sendDeliveryFeedback = $value;
     }
 
     protected function twig(): Environment


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-2367](https://issues.ibexa.co/browse/IBX-2367)
| **Type**                                   | improvement
| **Target Ibexa DXP version** | `v3.3.15`
| **BC breaks**                          | no
| **Doc needed**                       | no

Method `sendDeliveryFeedback` generates `rendered` events improperly before items are rendered. After internal discussion we decided to drop it for now.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/php-dev-team`).
