### PR TITLE
Fixed RepositoryConfigResolverTest

### DIFF
--- a/tests/lib/Config/Repository/RepositoryConfigResolverTest.php
+++ b/tests/lib/Config/Repository/RepositoryConfigResolverTest.php
@@ -40,7 +40,6 @@ final class RepositoryConfigResolverTest extends TestCase
     public function testDoNotUseRemoteIdWhenParameterIsNotDefined(): void
     {
         $this->mockConfigResolverHasParameter(false);
-        $this->mockConfigResolverGetParameter(false);
 
         self::assertFalse($this->repositoryConfigResolver->useRemoteId());
     }


### PR DESCRIPTION
In case when parameter related to switch between numeric and remote id is not defined `ConfigResolver::getParamter` shouldn't be called to fetch parameter value.