### PR TITLE
Refactored ContentTypeHelper

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -661,11 +661,6 @@ parameters:
 			path: src/lib/Generator/ContentListElementGenerator.php
 
 		-
-			message: "#^Cannot access property \\$contentInfo on eZ\\\\Publish\\\\API\\\\Repository\\\\Values\\\\Content\\\\Content\\|null\\.$#"
-			count: 1
-			path: src/lib/Helper/ContentHelper.php
-
-		-
 			message: "#^Method EzSystems\\\\EzRecommendationClient\\\\Helper\\\\ContentHelper\\:\\:countContentItemsByContentTypeId\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/lib/Helper/ContentHelper.php

--- a/src/bundle/Templating/Twig/Functions/UserTracking.php
+++ b/src/bundle/Templating/Twig/Functions/UserTracking.php
@@ -65,17 +65,17 @@ final class UserTracking implements RuntimeExtensionInterface
      */
     public function trackUser(Content $content): ?string
     {
-        $contentInfo = $content->contentInfo;
-        if ($this->contentTypeHelper->isContentTypeExcluded($contentInfo)) {
+        $contentType = $content->getContentType();
+        if ($this->contentTypeHelper->isContentTypeExcluded($contentType)) {
             return null;
         }
 
-        $contentId = $this->repositoryConfigResolver->useRemoteId() ? $contentInfo->remoteId : $content->id;
+        $contentId = $this->repositoryConfigResolver->useRemoteId() ? $content->contentInfo->remoteId : $content->id;
 
         return $this->render(
             [
                 'contentId' => $contentId,
-                'contentTypeId' => $content->getContentType()->id,
+                'contentTypeId' => $contentType->id,
             ]
         );
     }

--- a/src/lib/Helper/ContentHelper.php
+++ b/src/lib/Helper/ContentHelper.php
@@ -125,8 +125,11 @@ final class ContentHelper implements LoggerAwareInterface
     public function getIncludedContent(int $contentId, ?array $languages = null, ?int $versionNo = null): ?Content
     {
         $content = $this->getContent($contentId, $languages, $versionNo);
+        if (null === $content) {
+            return null;
+        }
 
-        return !$this->contentTypeHelper->isContentTypeExcluded($content->contentInfo) ? $content : null;
+        return !$this->contentTypeHelper->isContentTypeExcluded($content->getContentType()) ? $content : null;
     }
 
     /**

--- a/src/lib/Helper/ContentTypeHelper.php
+++ b/src/lib/Helper/ContentTypeHelper.php
@@ -8,77 +8,29 @@ declare(strict_types=1);
 
 namespace EzSystems\EzRecommendationClient\Helper;
 
-use eZ\Publish\API\Repository\ContentService as ContentServiceInterface;
-use eZ\Publish\API\Repository\ContentTypeService as ContentTypeServiceInterface;
-use eZ\Publish\API\Repository\Repository as RepositoryInterface;
-use eZ\Publish\API\Repository\Values\Content\ContentInfo;
+use eZ\Publish\API\Repository\Values\ContentType\ContentType;
 use eZ\Publish\Core\MVC\ConfigResolverInterface;
 use EzSystems\EzRecommendationClient\Value\Parameters;
 
 final class ContentTypeHelper
 {
-    /** @var \eZ\Publish\API\Repository\ContentTypeService */
-    private $contentTypeService;
-
-    /** @var \eZ\Publish\API\Repository\ContentService */
-    private $contentService;
-
     /** @var \eZ\Publish\Core\MVC\ConfigResolverInterface */
     private $configResolver;
 
-    /** @var \eZ\Publish\API\Repository\Repository */
-    private $repository;
-
-    public function __construct(
-        ContentTypeServiceInterface $contentTypeService,
-        ContentServiceInterface $contentService,
-        RepositoryInterface $repository,
-        ConfigResolverInterface $configResolver
-    ) {
-        $this->contentTypeService = $contentTypeService;
-        $this->contentService = $contentService;
+    public function __construct(ConfigResolverInterface $configResolver)
+    {
         $this->configResolver = $configResolver;
-        $this->repository = $repository;
-    }
-
-    /**
-     * Returns ContentType ID based on $contentType name.
-     *
-     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
-     */
-    public function getContentTypeId(string $contentType): int
-    {
-        return $this->contentTypeService->loadContentTypeByIdentifier($contentType)->id;
-    }
-
-    /**
-     * Returns ContentType identifier based on $contentId.
-     *
-     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
-     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
-     */
-    public function getContentTypeIdentifier(int $contentId): string
-    {
-        return $this->contentTypeService->loadContentType(
-            $this->contentService
-                ->loadContent($contentId)
-                ->contentInfo
-                ->contentTypeId
-        )->identifier;
     }
 
     /**
      * @throws \Exception
      */
-    public function isContentTypeExcluded(ContentInfo $contentInfo): bool
+    public function isContentTypeExcluded(ContentType $contentType): bool
     {
-        $contentType = $this->repository->sudo(function () use ($contentInfo) {
-            return $this->contentTypeService->loadContentType($contentInfo->contentTypeId);
-        });
-
-        return !\in_array(
+        return !in_array(
             $contentType->identifier,
-            $this->configResolver->getParameter('included_content_types', Parameters::NAMESPACE)
+            $this->configResolver->getParameter('included_content_types', Parameters::NAMESPACE),
+            true
         );
     }
 }

--- a/src/lib/Service/EventNotificationService.php
+++ b/src/lib/Service/EventNotificationService.php
@@ -59,7 +59,7 @@ final class EventNotificationService extends NotificationService
     {
         $credentials = $this->clientCredentials->getCredentials();
 
-        if (!$credentials || $this->contentTypeHelper->isContentTypeExcluded($contentInfo)) {
+        if (!$credentials || $this->contentTypeHelper->isContentTypeExcluded($contentInfo->getContentType())) {
             return;
         }
 

--- a/tests/lib/Service/EventNotificationServiceTest.php
+++ b/tests/lib/Service/EventNotificationServiceTest.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace EzSystems\EzRecommendationClient\Tests\Service;
 
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
+use eZ\Publish\Core\Repository\Values\ContentType\ContentType;
 use EzSystems\EzRecommendationClient\API\Notifier;
 use EzSystems\EzRecommendationClient\Config\ExportCredentialsResolver;
 use EzSystems\EzRecommendationClient\Config\EzRecommendationClientCredentialsResolver;
@@ -92,7 +93,14 @@ class EventNotificationServiceTest extends NotificationServiceTest
         $this->notificationService->sendNotification(
             'onHideLocation',
             EventNotification::ACTION_UPDATE,
-            new ContentInfo([])
+            new ContentInfo([
+                'contentType' => new ContentType(
+                    [
+                        'id' => 1,
+                        'identifier' => 'foo',
+                    ]
+                ),
+            ])
         );
     }
 }


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **Type**                                   | improvement
| **Target Ibexa DXP version** | `v3.3.18` 
| **BC breaks**                          | no
| **Doc needed**                       | no

**List of changes:**
- Removed unused methods `getContentTypeId` and `getContentTypeIdentifier`
- Changed `isContentTypeExcluded` method signature. Now method allows to pass `ContentType` object instead of `ContentInfo`
- Get `ContentType` identifier directly from passed `ContentType` object

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/php-dev-team`).
