### PR TITLE
IBX-2597: Removing first Pesonalized block from page builder editor removes both previews

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
         "ramsey/uuid": "^3.9",
         "symfony/framework-bundle": "^5.0",
         "symfony/twig-bundle": "^5.0",
+        "symfony/webpack-encore-bundle": "^1.8",
         "webmozart/assert": "^1.0"
     },
     "require-dev": {
@@ -57,6 +58,7 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": false
     }
 }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -861,11 +861,6 @@ parameters:
 			path: src/lib/Service/ContentService.php
 
 		-
-			message: "#^Comparison operation \"\\>\" between int\\<1, max\\> and 0 is always true\\.$#"
-			count: 1
-			path: src/lib/Service/ContentService.php
-
-		-
 			message: "#^Method EzSystems\\\\EzRecommendationClient\\\\Service\\\\ContentService\\:\\:fetchContent\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/lib/Service/ContentService.php
@@ -882,21 +877,6 @@ parameters:
 
 		-
 			message: "#^Method EzSystems\\\\EzRecommendationClient\\\\Service\\\\ContentService\\:\\:prepareContent\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/lib/Service/ContentService.php
-
-		-
-			message: "#^Method EzSystems\\\\EzRecommendationClient\\\\Service\\\\ContentService\\:\\:prepareFields\\(\\) has parameter \\$fields with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/lib/Service/ContentService.php
-
-		-
-			message: "#^Method EzSystems\\\\EzRecommendationClient\\\\Service\\\\ContentService\\:\\:prepareFields\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/lib/Service/ContentService.php
-
-		-
-			message: "#^Method EzSystems\\\\EzRecommendationClient\\\\Service\\\\ContentService\\:\\:prepareFields\\(\\) should return array but returns array\\<int, mixed\\>\\|null\\.$#"
 			count: 1
 			path: src/lib/Service/ContentService.php
 

--- a/src/bundle/Controller/RecommendationController.php
+++ b/src/bundle/Controller/RecommendationController.php
@@ -75,12 +75,17 @@ class RecommendationController
         $this->encoreTagRenderer->reset();
         $this->entrypointLookupCollection->getEntrypointLookup('ezplatform')->reset();
 
-        return $response->setContent(
+        $response->setContent(
             $this->twig()->render($template, [
             'recommendations' => $event->getRecommendationItems(),
             'templateId' => Uuid::uuid4()->toString(),
             ])
         );
+
+        $this->encoreTagRenderer->reset();
+        $this->entrypointLookupCollection->getEntrypointLookup('ezplatform')->reset();
+
+        return $response;
     }
 
     protected function twig(): Environment

--- a/src/bundle/Controller/RecommendationController.php
+++ b/src/bundle/Controller/RecommendationController.php
@@ -9,13 +9,13 @@ declare(strict_types=1);
 namespace EzSystems\EzRecommendationClientBundle\Controller;
 
 use EzSystems\EzRecommendationClient\Config\CredentialsResolverInterface;
-use Symfony\WebpackEncoreBundle\Asset\TagRenderer;
-use Symfony\WebpackEncoreBundle\Asset\EntrypointLookupCollectionInterface;
 use EzSystems\EzRecommendationClient\Event\RecommendationResponseEvent;
 use Ramsey\Uuid\Uuid;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\WebpackEncoreBundle\Asset\EntrypointLookupCollectionInterface;
+use Symfony\WebpackEncoreBundle\Asset\TagRenderer;
 use Twig\Environment;
 
 class RecommendationController

--- a/src/bundle/Controller/RecommendationController.php
+++ b/src/bundle/Controller/RecommendationController.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 namespace EzSystems\EzRecommendationClientBundle\Controller;
 
 use EzSystems\EzRecommendationClient\Config\CredentialsResolverInterface;
+use Symfony\WebpackEncoreBundle\Asset\TagRenderer;
+use Symfony\WebpackEncoreBundle\Asset\EntrypointLookupCollectionInterface;
 use EzSystems\EzRecommendationClient\Event\RecommendationResponseEvent;
 use Ramsey\Uuid\Uuid;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -26,16 +28,26 @@ class RecommendationController
     /** @var \EzSystems\EzRecommendationClient\Config\CredentialsResolverInterface */
     private $credentialsResolver;
 
+    /** @var \Symfony\WebpackEncoreBundle\Asset\TagRenderer */
+    protected $encoreTagRenderer;
+
+    /** @var \Symfony\WebpackEncoreBundle\Asset\EntrypointLookupCollectionInterface */
+    private $entrypointLookupCollection;
+
     /** @var \Twig\Environment */
     private $twig;
 
     public function __construct(
         EventDispatcherInterface $eventDispatcher,
         CredentialsResolverInterface $credentialsResolver,
+        TagRenderer $encoreTagRenderer,
+        EntrypointLookupCollectionInterface $entrypointLookupCollection,
         Environment $twig
     ) {
         $this->eventDispatcher = $eventDispatcher;
         $this->credentialsResolver = $credentialsResolver;
+        $this->encoreTagRenderer = $encoreTagRenderer;
+        $this->entrypointLookupCollection = $entrypointLookupCollection;
         $this->twig = $twig;
     }
 
@@ -59,6 +71,9 @@ class RecommendationController
 
         $response = new Response();
         $response->setPrivate();
+
+        $this->encoreTagRenderer->reset();
+        $this->entrypointLookupCollection->getEntrypointLookup('ezplatform')->reset();
 
         return $response->setContent(
             $this->twig()->render($template, [

--- a/src/bundle/Controller/RecommendationController.php
+++ b/src/bundle/Controller/RecommendationController.php
@@ -29,7 +29,7 @@ class RecommendationController
     private $credentialsResolver;
 
     /** @var \Symfony\WebpackEncoreBundle\Asset\TagRenderer */
-    protected $encoreTagRenderer;
+    private $encoreTagRenderer;
 
     /** @var \Symfony\WebpackEncoreBundle\Asset\EntrypointLookupCollectionInterface */
     private $entrypointLookupCollection;

--- a/src/bundle/Resources/config/services/controllers.yaml
+++ b/src/bundle/Resources/config/services/controllers.yaml
@@ -11,6 +11,8 @@ services:
         public: true
         arguments:
             $credentialsResolver: '@EzSystems\EzRecommendationClient\Config\EzRecommendationClientCredentialsResolver'
+            $encoreTagRenderer: '@webpack_encore.tag_renderer'
+            $entrypointLookupCollection: '@webpack_encore.entrypoint_lookup_collection'
 
     ez_recommendation:
         alias: EzSystems\EzRecommendationClientBundle\Controller\RecommendationController

--- a/src/lib/Service/ContentService.php
+++ b/src/lib/Service/ContentService.php
@@ -254,10 +254,14 @@ final class ContentService implements ContentServiceInterface
 
     /**
      * Checks if fields are given, if not - returns all of them.
+     *
+     * @param array<string> $fields
+     *
+     * @return array<string>
      */
-    private function prepareFields(APIContentType $contentType, ?array $fields = null): array
+    private function prepareFields(APIContentType $contentType, array $fields): array
     {
-        if ($fields && \count($fields) > 0) {
+        if (empty($fields)) {
             return $fields;
         }
 


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | https://issues.ibexa.co/browse/IBX-2597
| **Type**                                   | bug
| **Target Ibexa DXP version** | `v3.3`
| **BC breaks**                          | no
| **Doc needed**                       | yes

This bug occurs because normally `encore_entry_link_tags` is loaded only once per request, but we add `{{ encore_entry_link_tags('ezplatform-personalization-css', null, 'ezplatform') }}` in each block tempate. Combination of this results in situation, where CSS file is included only in first block so when we remove first block, including proper CSS disappears completely from page and styling for all other blocks is broken (non existing to be more specific).

This PR uses this approach https://github.com/symfony/webpack-encore-bundle/tree/v1.16.1#rendering-multiple-times-in-a-request-eg-to-generate-a-pdf to reset internal cache.

Please be gentle in CR (:P), solution is taken in 100% from this fragment where similar case occurs: https://github.com/ezsystems/ezplatform-admin-ui/blob/aa7aa34282f46f65a7300368f5e955d484a74404/src/lib/EventListener/AdminExceptionListener.php

Argument `$fields` in method `ContentService::prepareFields` expects array of string - field identifiers. This can be empty array but will never be a null.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [ ] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/php-dev-team`).
